### PR TITLE
Bump package versions for editor web component and quml player

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@project-sunbird/ng2-semantic-ui": "8.0.2",
         "@project-sunbird/sb-styles": "0.0.16",
         "@project-sunbird/sunbird-file-upload-library": "1.0.2",
-        "@project-sunbird/sunbird-quml-player-web-component": "6.0.4",
+        "@project-sunbird/sunbird-quml-player-web-component": "6.0.6",
         "@project-sunbird/sunbird-resource-library": "8.0.2",
         "@project-sunbird/telemetry-sdk": "1.3.0",
         "@types/jquery": "^3.5.29",
@@ -5767,9 +5767,9 @@
       }
     },
     "node_modules/@project-sunbird/sunbird-quml-player-web-component": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component/-/sunbird-quml-player-web-component-6.0.4.tgz",
-      "integrity": "sha512-dwMLioIY3yUrKq32K6QSuH7lW8ob+F1xmQsRasepA64G7uwWeg3gVFlHdNBwd7fXjcwx5yOKVJpwwKxyOOM/vg==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component/-/sunbird-quml-player-web-component-6.0.6.tgz",
+      "integrity": "sha512-P+9bvIUVUp+QoA9HdN3ZEyqoi+ev0zGbl/Av4/Tk9q2c5yXcfbQyseEj74L39kI1ft+nqaMR4F1nPgq16TDIZg==",
       "license": "MIT"
     },
     "node_modules/@project-sunbird/sunbird-resource-library": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@project-sunbird/ng2-semantic-ui": "8.0.2",
     "@project-sunbird/sb-styles": "0.0.16",
     "@project-sunbird/sunbird-file-upload-library": "1.0.2",
-    "@project-sunbird/sunbird-quml-player-web-component": "6.0.4",
+    "@project-sunbird/sunbird-quml-player-web-component": "6.0.6",
     "@project-sunbird/sunbird-resource-library": "8.0.2",
     "@project-sunbird/telemetry-sdk": "1.3.0",
     "@types/jquery": "^3.5.29",

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@project-sunbird/sunbird-questionset-editor-web-component",
-    "version": "6.0.4",
+    "version": "6.0.5",
     "description": "The web component package for the sunbird questionset editor",
     "main": "assets/quml-editor/sunbird-questionset-editor.js",
     "scripts": {


### PR DESCRIPTION
## Summary

- Bumped `@project-sunbird/sunbird-questionset-editor-web-component` package version
- Updated `@project-sunbird/sunbird-quml-player-web-component` package version

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Web component builds and serves correctly with updated versions