### PR TITLE
fix: add contentType 'Asset' to asset/v1/create request payload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@project-sunbird/ng2-semantic-ui": "8.0.2",
         "@project-sunbird/sb-styles": "0.0.16",
         "@project-sunbird/sunbird-file-upload-library": "1.0.2",
-        "@project-sunbird/sunbird-quml-player-web-component": "6.0.7",
+        "@project-sunbird/sunbird-quml-player-web-component": "6.0.8",
         "@project-sunbird/sunbird-resource-library": "8.0.2",
         "@project-sunbird/telemetry-sdk": "1.3.0",
         "@types/jquery": "^3.5.29",
@@ -5767,9 +5767,9 @@
       }
     },
     "node_modules/@project-sunbird/sunbird-quml-player-web-component": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component/-/sunbird-quml-player-web-component-6.0.7.tgz",
-      "integrity": "sha512-bpTVkMgmjnNqU8q+LG8FozNhrIgsmmljU58hywzER72wN069ulJovGWar2xX3aKm4g/ZIGw30XBM2Kjo5fk0ug==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component/-/sunbird-quml-player-web-component-6.0.8.tgz",
+      "integrity": "sha512-9D/NwSd/cXmRF3oqLrF4J7V+KFkhY69XpFl2z5XPQXwTFAcOUosUUzFzZcugxs77kS1UO4qXyQLuiq7To0ZpVg==",
       "license": "MIT"
     },
     "node_modules/@project-sunbird/sunbird-resource-library": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@project-sunbird/ng2-semantic-ui": "8.0.2",
         "@project-sunbird/sb-styles": "0.0.16",
         "@project-sunbird/sunbird-file-upload-library": "1.0.2",
-        "@project-sunbird/sunbird-quml-player-web-component": "6.0.6",
+        "@project-sunbird/sunbird-quml-player-web-component": "6.0.7",
         "@project-sunbird/sunbird-resource-library": "8.0.2",
         "@project-sunbird/telemetry-sdk": "1.3.0",
         "@types/jquery": "^3.5.29",
@@ -5767,9 +5767,9 @@
       }
     },
     "node_modules/@project-sunbird/sunbird-quml-player-web-component": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component/-/sunbird-quml-player-web-component-6.0.6.tgz",
-      "integrity": "sha512-P+9bvIUVUp+QoA9HdN3ZEyqoi+ev0zGbl/Av4/Tk9q2c5yXcfbQyseEj74L39kI1ft+nqaMR4F1nPgq16TDIZg==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component/-/sunbird-quml-player-web-component-6.0.7.tgz",
+      "integrity": "sha512-bpTVkMgmjnNqU8q+LG8FozNhrIgsmmljU58hywzER72wN069ulJovGWar2xX3aKm4g/ZIGw30XBM2Kjo5fk0ug==",
       "license": "MIT"
     },
     "node_modules/@project-sunbird/sunbird-resource-library": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@project-sunbird/ng2-semantic-ui": "8.0.2",
     "@project-sunbird/sb-styles": "0.0.16",
     "@project-sunbird/sunbird-file-upload-library": "1.0.2",
-    "@project-sunbird/sunbird-quml-player-web-component": "6.0.6",
+    "@project-sunbird/sunbird-quml-player-web-component": "6.0.7",
     "@project-sunbird/sunbird-resource-library": "8.0.2",
     "@project-sunbird/telemetry-sdk": "1.3.0",
     "@types/jquery": "^3.5.29",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@project-sunbird/ng2-semantic-ui": "8.0.2",
     "@project-sunbird/sb-styles": "0.0.16",
     "@project-sunbird/sunbird-file-upload-library": "1.0.2",
-    "@project-sunbird/sunbird-quml-player-web-component": "6.0.7",
+    "@project-sunbird/sunbird-quml-player-web-component": "6.0.8",
     "@project-sunbird/sunbird-resource-library": "8.0.2",
     "@project-sunbird/telemetry-sdk": "1.3.0",
     "@types/jquery": "^3.5.29",

--- a/projects/questionset-editor-library/src/lib/services/question/question.service.ts
+++ b/projects/questionset-editor-library/src/lib/services/question/question.service.ts
@@ -100,6 +100,7 @@ export class QuestionService {
         request: {
           asset: {
             primaryCategory: 'asset',
+            contentType: 'Asset',
             language: ['English'],
             code: uuidv4(),
           }

--- a/projects/questionset-editor-library/src/lib/services/question/question.service.ts
+++ b/projects/questionset-editor-library/src/lib/services/question/question.service.ts
@@ -99,8 +99,7 @@ export class QuestionService {
       data: {
         request: {
           asset: {
-            primaryCategory: 'asset',
-            contentType: 'Asset',
+            primaryCategory: 'Asset',
             language: ['English'],
             code: uuidv4(),
           }

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@project-sunbird/sunbird-questionset-editor-web-component",
-    "version": "6.0.5",
+    "version": "6.0.6",
     "description": "The web component package for the sunbird questionset editor",
     "main": "assets/quml-editor/sunbird-questionset-editor.js",
     "scripts": {


### PR DESCRIPTION
## Summary
- Updated the Primary category value to uppercase
- Bumped editor web component package version

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Uploaded an image via the asset upload modal — `contentType: 'Asset'` now present in the create request payload