### PR TITLE
feat: mcq-boolean support added 

### DIFF
--- a/projects/questionset-editor-library/src/lib/components/boolean/boolean.component.html
+++ b/projects/questionset-editor-library/src/lib/components/boolean/boolean.component.html
@@ -1,0 +1,45 @@
+<ng-container *ngIf="!isReadOnlyMode; else readOnlyContainer">
+  <div class="d-flex pt-10 flex-dc sb-mcq-form">
+    <div class="d-flex sb-mcq-item flex-w-wrap" *ngFor="let option of editorState.options; let i = index">
+      <div class="sb-w-85 sb-ckeditor relative mb-15">
+        <lib-ckeditor-tool [setCharacterLimit]="setCharacterLimit"
+          (editorDataOutput)="setOptionBody(option, $event.body); option.length = $event.length; editorDataHandler($event)"
+          [editorDataInput]="optionBody(option)" [lang]="globalLang" class="ckeditor-tool__option mb-10"
+          [class.mb-5]="showFormError && ([undefined, ''].includes(optionBody(option)) || option.length > setCharacterLimit)"
+          [showLangSelector]="true" [langs]="langs" [activeLangCode]="currentLang" (langChange)="onLangChange($event)">
+        </lib-ckeditor-tool>
+        <label *ngIf="showFormError && !optionBody(option)" class="sb-color-error fs-0-785">{{configService.labelConfig?.lbl?.fillThisOption}}</label>
+        <label *ngIf="option.length > setCharacterLimit" class="ui basic red error label pt-1">
+          {{configService.labelConfig?.lbl?.reduceSize}}</label>
+      </div>
+      <div class="sb-checkbox sb-checkbox-primary pl-10 mt-0 pt-0" [class.selected]="option.selected === true" *ngIf="sourcingSettings?.enforceCorrectAnswer !== false">
+        <input type="checkbox" id="answer_{{ i + 1 }}" name="example" value="{{ i }}"  (click)="onOptionChange($event);"
+        [checked]="option.selected === true"
+        libTelemetryInteract
+        [telemetryInteractEdata]="telemetryService.getTelemetryInteractEdata('mark_as_right_anwser','click',undefined,telemetryService.telemetryPageId,{answer:i.toString()})" />
+        <label for="answer_{{ i + 1 }}" class="mr-0 fs-0-785">{{configService.labelConfig?.lbl?.correctAns}}</label>
+      </div>
+    </div>
+  </div>
+</ng-container>
+
+<ng-template #readOnlyContainer>
+  <div class="row mb-0 p-0" *ngFor="let option of editorState.options; let i=index">
+    <div class="twelve wide column p-0">
+      <div class="ckeditor-tool width-100">
+        <div class="ckeditor-tool__question-readonly mb-24">
+          <label class="px-16 py-8 fs-0-92 mb-0 ckeditor-tool__label width-100">Option {{ i+1 }}</label>
+          <div class="ckeditor-tool__solution__body">
+            <p class="fs-0-785 p-16" [innerHTML]="option.body | sanitizeHtml"></p>
+            <div class="mcq-checkbox-answer" *ngIf="editorState.answer === i">
+              <div class="sb-checkbox sb-checkbox-primary mr-auto selected">
+                <input type="checkbox" id="check1" name="example" disabled checked>
+                <label for="check1">{{configService.labelConfig?.lbl?.correctAns}}</label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</ng-template>

--- a/projects/questionset-editor-library/src/lib/components/boolean/boolean.component.html
+++ b/projects/questionset-editor-library/src/lib/components/boolean/boolean.component.html
@@ -1,5 +1,7 @@
 <ng-container *ngIf="!isReadOnlyMode; else readOnlyContainer">
   <div class="d-flex pt-10 flex-dc sb-mcq-form">
+    <label *ngIf="showFormError && editorState.answer == undefined && sourcingSettings?.enforceCorrectAnswer !== false" class="ui basic red error label pt-1 mt-10">
+      {{configService.labelConfig?.lbl?.selectOneAns}}</label>
     <div class="d-flex sb-mcq-item flex-w-wrap" *ngFor="let option of editorState.options; let i = index">
       <div class="sb-w-85 sb-ckeditor relative mb-15">
         <lib-ckeditor-tool [setCharacterLimit]="setCharacterLimit"

--- a/projects/questionset-editor-library/src/lib/components/boolean/boolean.component.scss
+++ b/projects/questionset-editor-library/src/lib/components/boolean/boolean.component.scss
@@ -1,0 +1,5 @@
+// Minimal SCSS file reusing existing class names
+.sb-mcq-form {
+  display: flex;
+  flex-direction: column;
+}

--- a/projects/questionset-editor-library/src/lib/components/boolean/boolean.component.spec.ts
+++ b/projects/questionset-editor-library/src/lib/components/boolean/boolean.component.spec.ts
@@ -1,0 +1,103 @@
+import { TelemetryInteractDirective } from '../../directives/telemetry-interact/telemetry-interact.directive';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FormsModule } from '@angular/forms';
+import { BooleanComponent } from './boolean.component';
+import { CUSTOM_ELEMENTS_SCHEMA, SimpleChange } from '@angular/core';
+import { ConfigService } from '../../services/config/config.service';
+import { SuiModule } from '@project-sunbird/ng2-semantic-ui';
+import { TreeService } from '../../services/tree/tree.service';
+import { EditorTelemetryService } from '../../services/telemetry/telemetry.service';
+import { EditorService } from "../../services/editor/editor.service";
+import { McqOptions } from '../../interfaces/McqForm';
+
+const mockEditorService = {
+  editorConfig: {
+    config: {
+      renderTaxonomy: true,
+      hierarchy: {
+        level1: {
+          name: "Module",
+          type: "Unit",
+          mimeType: "application/vnd.ekstep.content-collection",
+          contentType: "Course Unit",
+          iconClass: "fa fa-folder-o",
+          children: {},
+        },
+      },
+    },
+  },
+  parentIdentifier: ""
+};
+
+describe('BooleanComponent', () => {
+  let component: BooleanComponent;
+  let fixture: ComponentFixture<BooleanComponent>;
+  let treeService, telemetryService;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ HttpClientTestingModule, FormsModule, SuiModule ],
+      declarations: [ BooleanComponent, TelemetryInteractDirective ],
+      providers: [
+        ConfigService,
+        TreeService,
+        EditorTelemetryService,
+        { provide: EditorService, useValue: mockEditorService }
+      ],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BooleanComponent);
+    treeService = TestBed.inject(TreeService);
+    telemetryService = TestBed.inject(EditorTelemetryService);
+    component = fixture.componentInstance;
+    component.sourcingSettings = { enforceCorrectAnswer: true, showAddScore: false };
+    component.editorState = {
+      question: '<p>Is this true?</p>',
+      options: [
+        new McqOptions('<p>True</p>'),
+        new McqOptions('<p>False</p>')
+      ],
+      answer: 0
+    };
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('#ngOnInit() should call addSelectedOptions and editorDataHandler', () => {
+    spyOn(component, 'addSelectedOptions').and.callThrough();
+    spyOn(component, 'editorDataHandler');
+    component.ngOnInit();
+    expect(component.addSelectedOptions).toHaveBeenCalled();
+    expect(component.editorDataHandler).toHaveBeenCalled();
+    expect(component.editorState.options.length).toBe(2);
+  });
+
+  it('#onOptionChange() should update selected option and emit data', () => {
+    spyOn(component, 'editorDataHandler');
+    spyOn(component, 'setMapping');
+    const mockEvent = { target: { value: '1', checked: true } };
+    component.onOptionChange(mockEvent);
+    expect(component.editorState.answer).toBe(1);
+    expect(component.selectedOptions).toEqual([1]);
+    expect(component.editorState.options[0]['selected']).toBe(false);
+    expect(component.editorState.options[1]['selected']).toBe(true);
+    expect(component.setMapping).toHaveBeenCalled();
+    expect(component.editorDataHandler).toHaveBeenCalled();
+  });
+
+  it('#prepareMcqBody() should return expected metadata with qType BOOL', () => {
+    component.maxScore = 1;
+    const body = component.prepareMcqBody(component.editorState);
+    expect(body.qType).toEqual('BOOL');
+    expect(body.primaryCategory).toEqual('Boolean Question');
+    expect(body.templateId).toEqual('mcq-boolean');
+    expect(body.responseDeclaration.response1.cardinality).toEqual('single');
+  });
+});

--- a/projects/questionset-editor-library/src/lib/components/boolean/boolean.component.ts
+++ b/projects/questionset-editor-library/src/lib/components/boolean/boolean.component.ts
@@ -1,0 +1,209 @@
+import { Component, OnInit, Input, EventEmitter, Output } from '@angular/core';
+import * as _ from 'lodash-es';
+import { McqOptions } from '../../interfaces/McqForm';
+import { ActiveLanguageService } from '../../services/language/active-language.service';
+import { readI18nForEditor, writeI18n, I18nValue } from '../../utils/i18nField';
+import { EditorTelemetryService } from '../../services/telemetry/telemetry.service';
+import { ConfigService } from '../../services/config/config.service';
+import { TreeService } from '../../services/tree/tree.service';
+import { EditorService } from '../../services/editor/editor.service';
+
+@Component({
+  selector: 'lib-boolean',
+  templateUrl: './boolean.component.html',
+  styleUrls: ['./boolean.component.scss'],
+  standalone: false,
+})
+export class BooleanComponent implements OnInit {
+  @Input() editorState: any;
+  @Input() showFormError;
+  @Input() sourcingSettings;
+  @Input() questionPrimaryCategory;
+  @Input() mapping = [];
+  @Input() isReadOnlyMode;
+  @Input() maxScore;
+  private _activeLang: ActiveLanguageService;
+  private _langSub: any;
+  @Input() set activeLang(val: ActiveLanguageService) {
+    this._activeLang = val;
+    if (val) {
+      if (this._langSub) { this._langSub.unsubscribe(); }
+      this._langSub = val.lang$.subscribe(l => { this.currentLang = l; });
+    }
+  }
+  get activeLang(): ActiveLanguageService { return this._activeLang; }
+  @Output() editorDataOutput: EventEmitter<any> = new EventEmitter<any>();
+
+  currentLang = 'en';
+  get lang(): string { return this.currentLang; }
+  get globalLang(): string { return localStorage.getItem('app-language') || 'en'; }
+  get globalDir(): string { return this.globalLang === 'ar' ? 'rtl' : 'ltr'; }
+  langs = ActiveLanguageService.LANGS;
+  onLangChange(code: string): void { this._activeLang?.set(code); }
+  optionBody(option: any): string { return readI18nForEditor(option.body as I18nValue, this.lang); }
+  setOptionBody(option: any, value: string): void {
+    option.body = writeI18n(option.body as I18nValue, this.lang, value);
+  }
+  public setCharacterLimit = 160;
+  public setImageLimit = 1;
+  public templateType = 'mcq-boolean';
+  parentMeta: any;
+  selectedOptions = [];
+
+  constructor(
+    public telemetryService: EditorTelemetryService,
+    public configService: ConfigService,
+    public treeService: TreeService,
+    private editorService: EditorService
+  ) { }
+
+  ngOnInit() {
+    if (!this.editorState) {
+      this.editorState = {};
+    }
+    if (!this.editorState.options || this.editorState.options.length !== 2) {
+      this.editorState.options = [
+        new McqOptions('<p>True</p>'),
+        new McqOptions('<p>False</p>'),
+      ];
+      this.editorService.optionsLength = 2;
+      this.editorState.maximumOptions = 2;
+    }
+    if (_.isUndefined(this.editorState.answer) || !_.includes([0, 1], this.editorState.answer)) {
+      this.editorState.answer = 0;
+    }
+    this.addSelectedOptions();
+    this.mapping = _.get(this.editorState, 'responseDeclaration.response1.mapping') || [];
+    this.editorDataHandler();
+    if (!_.isUndefined(this.editorService.editorConfig.config.renderTaxonomy)) {
+      this.parentMeta = this.treeService.getFirstChild().data.metadata;
+    }
+  }
+
+  addSelectedOptions() {
+    if (_.isNumber(this.editorState.answer)) {
+      this.selectedOptions = [this.editorState.answer];
+    } else if (_.isArray(this.editorState.answer)) {
+      this.selectedOptions = this.editorState.answer;
+    }
+    if (!_.isEmpty(this.editorState.options)) {
+      _.forEach(this.editorState.options, (option, index) => {
+        const resindex = Number(index);
+        option['selected'] = _.includes(this.selectedOptions, resindex);
+      });
+    }
+  }
+
+  editorDataHandler(event?) {
+    const body = this.prepareMcqBody(this.editorState);
+    this.editorDataOutput.emit({ body, mediaobj: event ? event.mediaobj : undefined });
+  }
+
+  prepareMcqBody(editorState) {
+    let metadata: any;
+    const correctAnswer = editorState.answer;
+    let resindex;
+    const options = _.map(editorState.options, (opt, key) => {
+      resindex = Number(key);
+      const isCorrect = (correctAnswer === resindex) || (_.isArray(correctAnswer) && _.includes(correctAnswer, resindex));
+      return { answer: isCorrect, value: { body: opt.body, value: resindex } };
+    });
+
+    metadata = {
+      templateId: this.templateType,
+      name: this.questionPrimaryCategory || 'Boolean Question',
+      responseDeclaration: this.getResponseDeclaration(editorState),
+      outcomeDeclaration: this.getOutcomeDeclaration(),
+      interactionTypes: ['choice'],
+      interactions: this.getInteractions(editorState.options),
+      editorState: {
+        options,
+      },
+      qType: 'BOOL',
+      primaryCategory: this.questionPrimaryCategory || 'Boolean Question',
+    };
+    return metadata;
+  }
+
+  getResponseDeclaration(editorState) {
+    return {
+      response1: {
+        cardinality: 'single',
+        type: 'integer',
+        correctResponse: {
+          value: editorState.answer,
+        },
+        mapping: this.mapping,
+      },
+    };
+  }
+
+  getOutcomeDeclaration() {
+    return {
+      maxScore: {
+        cardinality: 'single',
+        type: 'integer',
+        defaultValue: this.maxScore
+      }
+    };
+  }
+
+  getInteractions(options) {
+    let index;
+    const interactOptions = _.map(options, (opt, key) => {
+      index = Number(key);
+      const bodyI18n = typeof opt.body === 'object' ? opt.body : (opt.body ? { en: opt.body } : {});
+      return {
+        label: bodyI18n,
+        value: index,
+        hint: ''
+      };
+    });
+    return {
+      response1: {
+        type: 'choice',
+        options: interactOptions,
+      },
+    };
+  }
+
+  onOptionChange(event) {
+    const optionIndex = _.parseInt(event.target.value);
+    this.selectedOptions = [optionIndex];
+    this.editorState.answer = optionIndex;
+    if (!_.isEmpty(this.editorState.options)) {
+      _.forEach(this.editorState.options, (option, index) => {
+        option['selected'] = (Number(index) === optionIndex);
+      });
+    }
+    this.setMapping();
+    this.editorDataHandler();
+  }
+
+  setMapping() {
+    if (!_.isEmpty(this.selectedOptions)) {
+      this.mapping = [];
+      const scoreForEachOption = _.round((this.maxScore / this.selectedOptions.length), 2);
+      _.forEach(this.selectedOptions, (value) => {
+        const optionMapping = {
+          value: value,
+          score: scoreForEachOption,
+        };
+        this.mapping.push(optionMapping);
+      });
+    } else {
+      this.mapping = [];
+    }
+  }
+
+  setScore(value, scoreIndex) {
+    const obj = {
+      response: scoreIndex,
+      outcomes: {
+        score: value,
+      },
+    };
+    this.mapping[scoreIndex] = obj;
+    this.editorDataHandler();
+  }
+}

--- a/projects/questionset-editor-library/src/lib/components/boolean/boolean.component.ts
+++ b/projects/questionset-editor-library/src/lib/components/boolean/boolean.component.ts
@@ -68,9 +68,13 @@ export class BooleanComponent implements OnInit {
       ];
       this.editorService.optionsLength = 2;
       this.editorState.maximumOptions = 2;
-    }
-    if (_.isUndefined(this.editorState.answer) || !_.includes([0, 1], this.editorState.answer)) {
-      this.editorState.answer = 0;
+    } else {
+      if (!this.optionBody(this.editorState.options[0])) {
+        this.setOptionBody(this.editorState.options[0], '<p>True</p>');
+      }
+      if (!this.optionBody(this.editorState.options[1])) {
+        this.setOptionBody(this.editorState.options[1], '<p>False</p>');
+      }
     }
     this.addSelectedOptions();
     this.mapping = _.get(this.editorState, 'responseDeclaration.response1.mapping') || [];

--- a/projects/questionset-editor-library/src/lib/components/options/options.component.html
+++ b/projects/questionset-editor-library/src/lib/components/options/options.component.html
@@ -6,7 +6,8 @@
     <span class="divider mr-8"></span>
     <span><button class="sb-btn sb-btn-xs sb-btn-outline-gray mr-5 q-sb-layout-single" [ngClass]="{active: 'mcq-vertical' === templateType}" (click)="setTemplete('mcq-vertical')"><i class="mr-10 h-7"></i> {{configService.labelConfig?.lbl?.vertical}}</button></span>
     <span><button class="sb-btn sb-btn-xs sb-btn-outline-gray mr-5 q-sb-layout-two" [ngClass]="{active: 'mcq-vertical-split' === templateType}" (click)="setTemplete('mcq-vertical-split')"><i class="mr-10 h-7 w-20"></i>{{configService.labelConfig?.lbl?.grid}}</button></span>
-    <span><button class="sb-btn sb-btn-xs sb-btn-outline-gray q-sb-layout-three" [ngClass]="{active: 'mcq-horizontal' === templateType}" (click)="setTemplete('mcq-horizontal')"> <i class="mr-10 h-7"></i> {{configService.labelConfig?.lbl?.horizontal}}</button></span>
+    <span><button class="sb-btn sb-btn-xs sb-btn-outline-gray mr-5 q-sb-layout-three" [ngClass]="{active: 'mcq-horizontal' === templateType}" (click)="setTemplete('mcq-horizontal')"> <i class="mr-10 h-7"></i> {{configService.labelConfig?.lbl?.horizontal}}</button></span>
+    <span><button class="sb-btn sb-btn-xs sb-btn-outline-gray q-sb-layout-boolean" [ngClass]="{active: 'mcq-boolean' === templateType}" (click)="setTemplete('mcq-boolean')"><i class="mr-10 h-7"></i> {{configService.labelConfig?.lbl?.boolean}}</button></span>
   </div>
   <label *ngIf="showFormError && editorState.answer == undefined && sourcingSettings?.enforceCorrectAnswer" class="ui basic red error label pt-1 mt-10">
     {{configService.labelConfig?.lbl?.selectOneAns}}</label>

--- a/projects/questionset-editor-library/src/lib/components/options/options.component.html
+++ b/projects/questionset-editor-library/src/lib/components/options/options.component.html
@@ -7,7 +7,6 @@
     <span><button class="sb-btn sb-btn-xs sb-btn-outline-gray mr-5 q-sb-layout-single" [ngClass]="{active: 'mcq-vertical' === templateType}" (click)="setTemplete('mcq-vertical')"><i class="mr-10 h-7"></i> {{configService.labelConfig?.lbl?.vertical}}</button></span>
     <span><button class="sb-btn sb-btn-xs sb-btn-outline-gray mr-5 q-sb-layout-two" [ngClass]="{active: 'mcq-vertical-split' === templateType}" (click)="setTemplete('mcq-vertical-split')"><i class="mr-10 h-7 w-20"></i>{{configService.labelConfig?.lbl?.grid}}</button></span>
     <span><button class="sb-btn sb-btn-xs sb-btn-outline-gray mr-5 q-sb-layout-three" [ngClass]="{active: 'mcq-horizontal' === templateType}" (click)="setTemplete('mcq-horizontal')"> <i class="mr-10 h-7"></i> {{configService.labelConfig?.lbl?.horizontal}}</button></span>
-    <span><button class="sb-btn sb-btn-xs sb-btn-outline-gray q-sb-layout-boolean" [ngClass]="{active: 'mcq-boolean' === templateType}" (click)="setTemplete('mcq-boolean')"><i class="mr-10 h-7"></i> {{configService.labelConfig?.lbl?.boolean}}</button></span>
   </div>
   <label *ngIf="showFormError && editorState.answer == undefined && sourcingSettings?.enforceCorrectAnswer" class="ui basic red error label pt-1 mt-10">
     {{configService.labelConfig?.lbl?.selectOneAns}}</label>

--- a/projects/questionset-editor-library/src/lib/components/options/options.component.scss
+++ b/projects/questionset-editor-library/src/lib/components/options/options.component.scss
@@ -95,6 +95,16 @@
   }
 }
 
+.q-sb-layout-boolean{
+  &.active,
+  &:hover
+  {
+    border-color: var(--primary-400);
+    background-color: #ffffff;
+    color: var(--primary-400);
+  }
+}
+
 .h-7 {
   height: 7px;
 }

--- a/projects/questionset-editor-library/src/lib/components/options/options.component.scss
+++ b/projects/questionset-editor-library/src/lib/components/options/options.component.scss
@@ -95,15 +95,6 @@
   }
 }
 
-.q-sb-layout-boolean{
-  &.active,
-  &:hover
-  {
-    border-color: var(--primary-400);
-    background-color: #ffffff;
-    color: var(--primary-400);
-  }
-}
 
 .h-7 {
   height: 7px;

--- a/projects/questionset-editor-library/src/lib/components/options/options.component.ts
+++ b/projects/questionset-editor-library/src/lib/components/options/options.component.ts
@@ -65,6 +65,10 @@ export class OptionsComponent implements OnInit, OnChanges {
     if (!_.isUndefined(this.editorState.templateId)) {
       this.templateType = this.editorState.templateId;
     }
+    if (this.templateType === 'mcq-boolean') {
+      this.editorService.optionsLength = 2;
+      this.editorState.maximumOptions = 2;
+    }
     this.mapping = _.get(this.editorState, 'responseDeclaration.response1.mapping') || [];
     this.editorDataHandler();
     if (!_.isUndefined(this.editorService.editorConfig.config.renderTaxonomy)) {

--- a/projects/questionset-editor-library/src/lib/components/options/options.component.ts
+++ b/projects/questionset-editor-library/src/lib/components/options/options.component.ts
@@ -65,10 +65,6 @@ export class OptionsComponent implements OnInit, OnChanges {
     if (!_.isUndefined(this.editorState.templateId)) {
       this.templateType = this.editorState.templateId;
     }
-    if (this.templateType === 'mcq-boolean') {
-      this.editorService.optionsLength = 2;
-      this.editorState.maximumOptions = 2;
-    }
     this.mapping = _.get(this.editorState, 'responseDeclaration.response1.mapping') || [];
     this.editorDataHandler();
     if (!_.isUndefined(this.editorService.editorConfig.config.renderTaxonomy)) {
@@ -220,21 +216,7 @@ export class OptionsComponent implements OnInit, OnChanges {
 
   setTemplete(template: string) {
     this.templateType = template;
-    if (template === 'mcq-boolean') {
-      // Boolean layout requires exactly 2 options pre-filled with True / False.
-      // Authors can still edit the labels (e.g. to Yes/No or a localised equivalent).
-      this.editorState.options = [
-        new McqOptions('<p>True</p>'),
-        new McqOptions('<p>False</p>'),
-      ];
-      this.editorService.optionsLength = 2;
-      this.editorState.answer = 0;
-      this.selectedOptions = [0];
-      this.mapping = [];
-      this.editorState.maximumOptions = 2;
-    } else {
-      this.editorState.maximumOptions = 4;
-    }
+    this.editorState.maximumOptions = 4;
     this.editorDataHandler();
   }
 
@@ -276,26 +258,12 @@ export class OptionsComponent implements OnInit, OnChanges {
 
   onOptionChange(event) {
     const optionIndex = _.parseInt(event.target.value);
-    if (this.templateType === 'mcq-boolean') {
-      if (event.target.checked === true) {
-        this.selectedOptions = [optionIndex];
-        _.forEach(this.editorState.options, (opt, idx) => {
-          opt.selected = idx === optionIndex;
-        });
-      } else {
-        this.selectedOptions = [];
-        _.forEach(this.editorState.options, (opt) => {
-          opt.selected = false;
-        });
-      }
-    } else {
-      if (event.target.checked === true && !_.includes(this.selectedOptions, optionIndex)) {
-        this.selectedOptions.push(optionIndex);
-      } else if (event.target.checked === false) {
-        _.remove(this.selectedOptions, (n) => {
-          return n === optionIndex;
-        });
-      }
+    if (event.target.checked === true && !_.includes(this.selectedOptions, optionIndex)) {
+      this.selectedOptions.push(optionIndex);
+    } else if (event.target.checked === false) {
+      _.remove(this.selectedOptions, (n) => {
+        return n === optionIndex;
+      });
     }
     if (this.selectedOptions.length === 1) {
       this.editorState.answer = this.selectedOptions[0];

--- a/projects/questionset-editor-library/src/lib/components/options/options.component.ts
+++ b/projects/questionset-editor-library/src/lib/components/options/options.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input, EventEmitter, Output, OnChanges, SimpleChanges } from '@angular/core';
 import * as _ from 'lodash-es';
+import { McqOptions } from '../../interfaces/McqForm';
 import { ActiveLanguageService } from '../../services/language/active-language.service';
 import { readI18nForEditor, writeI18n, I18nValue } from '../../utils/i18nField';
 import { EditorTelemetryService } from '../../services/telemetry/telemetry.service';
@@ -32,9 +33,9 @@ export class OptionsComponent implements OnInit, OnChanges {
   @Output() editorDataOutput: EventEmitter<any> = new EventEmitter<any>();
 
   currentLang = 'en';
-  get lang(): string    { return this.currentLang; }
+  get lang(): string { return this.currentLang; }
   get globalLang(): string { return localStorage.getItem('app-language') || 'en'; }
-  get globalDir(): string  { return this.globalLang === 'ar' ? 'rtl' : 'ltr'; }
+  get globalDir(): string { return this.globalLang === 'ar' ? 'rtl' : 'ltr'; }
   langs = ActiveLanguageService.LANGS;
   onLangChange(code: string): void { this._activeLang?.set(code); }
   optionBody(option: any): string { return readI18nForEditor(option.body as I18nValue, this.lang); }
@@ -45,8 +46,8 @@ export class OptionsComponent implements OnInit, OnChanges {
   public setImageLimit = 1;
   public templateType = 'mcq-vertical';
   subMenus: SubMenu[][];
-  hints:any = {};
-  showSubMenu:boolean=false;
+  hints: any = {};
+  showSubMenu: boolean = false;
   parentMeta: any;
   selectedOptions = [];
   constructor(
@@ -54,11 +55,11 @@ export class OptionsComponent implements OnInit, OnChanges {
     public configService: ConfigService,
     public treeService: TreeService,
     private editorService: EditorService
-  ) {}
+  ) { }
 
   ngOnInit() {
     this.hints = this.editorState.hints ? this.editorState.hints : {};
-    if(!_.isUndefined(this.editorState.answer)) {
+    if (!_.isUndefined(this.editorState.answer)) {
       this.addSelectedOptions();
     }
     if (!_.isUndefined(this.editorState.templateId)) {
@@ -66,13 +67,13 @@ export class OptionsComponent implements OnInit, OnChanges {
     }
     this.mapping = _.get(this.editorState, 'responseDeclaration.response1.mapping') || [];
     this.editorDataHandler();
-    if(!_.isUndefined(this.editorService.editorConfig.config.renderTaxonomy)){
+    if (!_.isUndefined(this.editorService.editorConfig.config.renderTaxonomy)) {
       this.parentMeta = this.treeService.getFirstChild().data.metadata;
-      this.showSubMenu=true;
+      this.showSubMenu = true;
     }
   }
 
-  ngOnChanges(changes: SimpleChanges){
+  ngOnChanges(changes: SimpleChanges) {
     if (!_.isUndefined(changes.maxScore.previousValue) && !_.isNaN(changes.maxScore.currentValue)) {
       this.setMapping();
       this.editorDataHandler();
@@ -133,7 +134,7 @@ export class OptionsComponent implements OnInit, OnChanges {
       outcomeDeclaration: this.getOutcomeDeclaration(),
       interactionTypes: ['choice'],
       interactions: this.getInteractions(editorState.options),
-      hints:this.hints,
+      hints: this.hints,
       editorState: {
         options,
       },
@@ -178,9 +179,9 @@ export class OptionsComponent implements OnInit, OnChanges {
   }
 
   setMapping() {
-    if(!_.isEmpty(this.selectedOptions)) {
+    if (!_.isEmpty(this.selectedOptions)) {
       this.mapping = [];
-      const scoreForEachOption = _.round((this.maxScore/this.selectedOptions.length), 2);
+      const scoreForEachOption = _.round((this.maxScore / this.selectedOptions.length), 2);
       _.forEach(this.selectedOptions, (value) => {
         const optionMapping = {
           value: value,
@@ -213,15 +214,30 @@ export class OptionsComponent implements OnInit, OnChanges {
     return interactions;
   }
 
-  setTemplete(template) {
+  setTemplete(template: string) {
     this.templateType = template;
+    if (template === 'mcq-boolean') {
+      // Boolean layout requires exactly 2 options pre-filled with True / False.
+      // Authors can still edit the labels (e.g. to Yes/No or a localised equivalent).
+      this.editorState.options = [
+        new McqOptions('<p>True</p>'),
+        new McqOptions('<p>False</p>'),
+      ];
+      this.editorService.optionsLength = 2;
+      this.editorState.answer = 0;
+      this.selectedOptions = [0];
+      this.mapping = [];
+      this.editorState.maximumOptions = 2;
+    } else {
+      this.editorState.maximumOptions = 4;
+    }
     this.editorDataHandler();
   }
 
   subMenuChange({ index, value }, optionIndex) {
-    if(value.length && Object.keys(this.hints).length < this.editorState.interactions.response1.options.length ) {
-      const hint = {[uuidv4()] : {en:value}}
-      this.hints = {...this.hints, ...hint}
+    if (value.length && Object.keys(this.hints).length < this.editorState.interactions.response1.options.length) {
+      const hint = { [uuidv4()]: { en: value } }
+      this.hints = { ...this.hints, ...hint }
       this.editorState.interactions.response1.options[optionIndex].hint = Object.keys(hint)[0]
     }
     else if (value.length) {
@@ -232,13 +248,13 @@ export class OptionsComponent implements OnInit, OnChanges {
   subMenuConfig(options) {
     this.subMenus = []
     options.map((opt, index) => {
-      const uuid  = _.get(this.editorState, `interactions.response1.options[${index}].hint`)
+      const uuid = _.get(this.editorState, `interactions.response1.options[${index}].hint`)
       this.subMenus[index] = [
         {
           id: 'addHint',
           name: 'Add Hint',
-          value: (():any => {
-            if(this.hints[uuid]) {
+          value: ((): any => {
+            if (this.hints[uuid]) {
               return this.hints[uuid].en
             }
             else {
@@ -256,22 +272,22 @@ export class OptionsComponent implements OnInit, OnChanges {
 
   onOptionChange(event) {
     const optionIndex = _.parseInt(event.target.value);
-      if(event.target.checked === true && !_.includes(this.selectedOptions, optionIndex)) {
-        this.selectedOptions.push(optionIndex);
-      } else if(event.target.checked === false) {
-        _.remove(this.selectedOptions, (n) => {
-          return n === optionIndex;
-        });
-      }
-      if (this.selectedOptions.length === 1) {
-        this.editorState.answer = this.selectedOptions[0];
-      } else if(this.selectedOptions.length > 1) {
-        this.editorState.answer = this.selectedOptions;
-      } else {
-        this.editorState.answer = undefined;
-      }
-      this.setMapping();
-      this.editorDataHandler();
+    if (event.target.checked === true && !_.includes(this.selectedOptions, optionIndex)) {
+      this.selectedOptions.push(optionIndex);
+    } else if (event.target.checked === false) {
+      _.remove(this.selectedOptions, (n) => {
+        return n === optionIndex;
+      });
+    }
+    if (this.selectedOptions.length === 1) {
+      this.editorState.answer = this.selectedOptions[0];
+    } else if (this.selectedOptions.length > 1) {
+      this.editorState.answer = this.selectedOptions;
+    } else {
+      this.editorState.answer = undefined;
+    }
+    this.setMapping();
+    this.editorDataHandler();
   }
 
   setScore(value, scoreIndex) {

--- a/projects/questionset-editor-library/src/lib/components/options/options.component.ts
+++ b/projects/questionset-editor-library/src/lib/components/options/options.component.ts
@@ -276,12 +276,26 @@ export class OptionsComponent implements OnInit, OnChanges {
 
   onOptionChange(event) {
     const optionIndex = _.parseInt(event.target.value);
-    if (event.target.checked === true && !_.includes(this.selectedOptions, optionIndex)) {
-      this.selectedOptions.push(optionIndex);
-    } else if (event.target.checked === false) {
-      _.remove(this.selectedOptions, (n) => {
-        return n === optionIndex;
-      });
+    if (this.templateType === 'mcq-boolean') {
+      if (event.target.checked === true) {
+        this.selectedOptions = [optionIndex];
+        _.forEach(this.editorState.options, (opt, idx) => {
+          opt.selected = idx === optionIndex;
+        });
+      } else {
+        this.selectedOptions = [];
+        _.forEach(this.editorState.options, (opt) => {
+          opt.selected = false;
+        });
+      }
+    } else {
+      if (event.target.checked === true && !_.includes(this.selectedOptions, optionIndex)) {
+        this.selectedOptions.push(optionIndex);
+      } else if (event.target.checked === false) {
+        _.remove(this.selectedOptions, (n) => {
+          return n === optionIndex;
+        });
+      }
     }
     if (this.selectedOptions.length === 1) {
       this.editorState.answer = this.selectedOptions[0];

--- a/projects/questionset-editor-library/src/lib/questionset-editor-library.module.ts
+++ b/projects/questionset-editor-library/src/lib/questionset-editor-library.module.ts
@@ -46,6 +46,7 @@ import { LanguageSelectorComponent } from './components/language-selector/langua
 import { ReorderComponent } from './components/reorder/reorder.component';
 import { ActiveLanguageService } from './services/language/active-language.service';
 import { DragDropModule } from '@angular/cdk/drag-drop';
+import { BooleanComponent } from './components/boolean/boolean.component';
 @NgModule({
   declarations: [
     QuestionsetEditorLibraryComponent,
@@ -58,6 +59,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
     MetaFormComponent,
     QuestionComponent,
     OptionsComponent,
+    BooleanComponent,
     AnswerComponent,
     CkeditorToolComponent,
     TemplateComponent,
@@ -89,6 +91,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
     EditorQuestionTypeRegistryService,
     ActiveLanguageService,
     { provide: EDITOR_QUESTION_TYPE_REGISTRY, useValue: { primaryCategory: 'multiple choice question', interactionType: 'choice', qType: 'MCQ', component: OptionsComponent }, multi: true },
+    { provide: EDITOR_QUESTION_TYPE_REGISTRY, useValue: { primaryCategory: 'boolean question', interactionType: 'choice', qType: 'BOOL', component: BooleanComponent }, multi: true },
     { provide: EDITOR_QUESTION_TYPE_REGISTRY, useValue: { primaryCategory: 'subjective question', interactionType: 'default', qType: 'SA', component: AnswerComponent }, multi: true },
     { provide: EDITOR_QUESTION_TYPE_REGISTRY, useValue: { primaryCategory: 'ftb question', interactionType: 'text', qType: 'FTB', component: FtbComponent }, multi: true },
     { provide: EDITOR_QUESTION_TYPE_REGISTRY, useValue: { primaryCategory: 'match the following question', interactionType: 'match', qType: 'MTF', component: MtfComponent }, multi: true },

--- a/projects/questionset-editor-library/src/lib/services/config/editor.config.json
+++ b/projects/questionset-editor-library/src/lib/services/config/editor.config.json
@@ -21,7 +21,7 @@
             "accepted": "mp3, wav"
           }
     },
-    "questionPrimaryCategories": ["Multiple Choice Question", "Subjective Question", "FTB Question", "Match The Following Question", "Sequence Question", "Reorder Question"],
+    "questionPrimaryCategories": ["Multiple Choice Question", "Boolean Question", "Subjective Question", "FTB Question", "Match The Following Question", "Sequence Question", "Reorder Question"],
     "contentPrimaryCategories": ["Course Assessment", "eTextbook", "Explanation Content", "Learning Resource", "Practice Question Set"],
     "readQuestionFields": "body,primaryCategory,mimeType,qType,answer,templateId,responseDeclaration,interactionTypes,interactions,name,solutions,editorState,media,remarks,evidence,hints,instructions,outcomeDeclaration,isPartialScore,evalUnordered,",
     "omitFalseyProperties":["topic", "topicsIds", "targetTopicIds", "keywords"],

--- a/projects/questionset-editor-library/src/lib/services/config/label.config.ar.json
+++ b/projects/questionset-editor-library/src/lib/services/config/label.config.ar.json
@@ -125,6 +125,7 @@
     "vertical": "عمودي",
     "grid": "شبكة",
     "horizontal": "أفقي",
+    "boolean": "منطقي (صح/خطأ)",
     "sliderValue": "قيمة المنزلق",
     "left": "يسار",
     "stepSize": "حجم الخطوة",

--- a/projects/questionset-editor-library/src/lib/services/config/label.config.ar.json
+++ b/projects/questionset-editor-library/src/lib/services/config/label.config.ar.json
@@ -227,6 +227,7 @@
   "categoryLabels": {
     "Multiselect Multiple Choice Question": "سؤال اختيار متعدد",
     "Multiple Choice Question": "سؤال الاختيار من متعدد",
+    "Boolean Question": "سؤال منطقي",
     "Subjective Question": "سؤال إنشائي",
     "FTB Question": "سؤال ملء الفراغات",
     "Match The Following Question": "سؤال المطابقة",

--- a/projects/questionset-editor-library/src/lib/services/config/label.config.fr.json
+++ b/projects/questionset-editor-library/src/lib/services/config/label.config.fr.json
@@ -125,6 +125,7 @@
     "vertical": "Vertical",
     "grid": "Grille",
     "horizontal": "Horizontal",
+    "boolean": "Booléen (Vrai/Faux)",
     "sliderValue": "Valeur du curseur",
     "left": "Gauche",
     "stepSize": "Taille du pas",

--- a/projects/questionset-editor-library/src/lib/services/config/label.config.fr.json
+++ b/projects/questionset-editor-library/src/lib/services/config/label.config.fr.json
@@ -227,6 +227,7 @@
   "categoryLabels": {
     "Multiselect Multiple Choice Question": "Question à choix multiple",
     "Multiple Choice Question": "Question à Choix Multiple",
+    "Boolean Question": "Question Booléenne",
     "Subjective Question": "Question Subjective",
     "FTB Question": "Question à Trous",
     "Match The Following Question": "Question d'Appariement",

--- a/projects/questionset-editor-library/src/lib/services/config/label.config.hi.json
+++ b/projects/questionset-editor-library/src/lib/services/config/label.config.hi.json
@@ -8,6 +8,7 @@
     "vertical": "ऊर्ध्वाधर",
     "grid": "ग्रिड",
     "horizontal": "क्षैतिज",
+    "boolean": "बूलियन (सही/गलत)",
     "selectOneAns": "एक सही उत्तर चुनें",
     "fillThisOption": "यह विकल्प भरें",
     "correctAns": "सही उत्तर",

--- a/projects/questionset-editor-library/src/lib/services/config/label.config.json
+++ b/projects/questionset-editor-library/src/lib/services/config/label.config.json
@@ -266,6 +266,7 @@
     }
   },
   "categoryLabels": {
-    "Multiselect Multiple Choice Question": "Multiple Choice Question"
+    "Multiselect Multiple Choice Question": "Multiple Choice Question",
+    "Boolean Question": "Boolean Question"
   }
 }

--- a/projects/questionset-editor-library/src/lib/services/config/label.config.json
+++ b/projects/questionset-editor-library/src/lib/services/config/label.config.json
@@ -137,6 +137,7 @@
     "vertical": "Vertical",
     "grid": "Grid",
     "horizontal": "Horizontal",
+    "boolean": "Boolean (True/False)",
     "sliderValue": "Slider Value",
     "left": "Left",
     "stepSize": "Step size",

--- a/projects/questionset-editor-library/src/lib/services/config/label.config.pt.json
+++ b/projects/questionset-editor-library/src/lib/services/config/label.config.pt.json
@@ -125,6 +125,7 @@
     "vertical": "Vertical",
     "grid": "Grade",
     "horizontal": "Horizontal",
+    "boolean": "Booleano (Verdadeiro/Falso)",
     "sliderValue": "Valor do Controle Deslizante",
     "left": "Esquerda",
     "stepSize": "Tamanho do passo",

--- a/projects/questionset-editor-library/src/lib/services/config/label.config.pt.json
+++ b/projects/questionset-editor-library/src/lib/services/config/label.config.pt.json
@@ -227,6 +227,7 @@
   "categoryLabels": {
     "Multiselect Multiple Choice Question": "Pergunta de Múltipla Escolha",
     "Multiple Choice Question": "Questão de Múltipla Escolha",
+    "Boolean Question": "Questão Booleana",
     "Subjective Question": "Questão Subjetiva",
     "FTB Question": "Questão de Preenchimento",
     "Match The Following Question": "Questão de Correspondência",


### PR DESCRIPTION
Summary
Adds Boolean (True/False) as a standalone question type in the editor. The boolean editor provides a simplified interface with exactly 2 pre-filled options (True/False), single-select correct answer enforcement, customizable option labels, and no add/delete option controls. Includes i18n labels for all 5 supported languages.
Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
How Has This Been Tested?
- [x] Verified boolean editor renders with 2 pre-filled True/False options
- [x] Verified single-select behavior — selecting one option deselects the other
- [x] Verified option labels are editable
- [x] Verified add/delete option controls are absent
- [x] Verified i18n labels display correctly in English, Hindi, French, Portuguese, Arabic
- [x] Verified boolean question saves and renders correctly in player preview
Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

<img width="1846" height="684" alt="image" src="https://github.com/user-attachments/assets/8ab8c859-e3d8-4cd2-8695-7f7d1786b8c3" />
<img width="1829" height="405" alt="image" src="https://github.com/user-attachments/assets/446d0dd4-8aad-4885-b623-8ef5d825a873" />
