### PR TITLE
fix: asset search primaryCategory, player preview list fetch, modal theme, static toast icons, close on workflow success

### DIFF
--- a/projects/questionset-editor-react/package-lock.json
+++ b/projects/questionset-editor-react/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@project-sunbird/ckeditor-build-classic": "^4.1.3",
-        "@project-sunbird/sunbird-quml-player-web-component-react": "^0.1.2",
+        "@project-sunbird/sunbird-quml-player-web-component-react": "^0.1.3",
         "@tanstack/react-query": "^5.51.0",
         "@tiptap/extension-code-block": "^3.27.1",
         "@tiptap/extension-image": "^3.27.1",
@@ -1747,9 +1747,9 @@
       }
     },
     "node_modules/@project-sunbird/sunbird-quml-player-web-component-react": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component-react/-/sunbird-quml-player-web-component-react-0.1.2.tgz",
-      "integrity": "sha512-l5JRbxbToc6yubGdOK5nAqIpY25pnBvO+DmXM0ksw1ThsqrBcg5i/elE4f5DswthvxVRmNB1J0rGWY43510lgA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component-react/-/sunbird-quml-player-web-component-react-0.1.3.tgz",
+      "integrity": "sha512-ibx5123DcR42j0VFJkli2nMZRC3Rq9mE0Cv/2xJVpGgSe4QXd0MH8dliAhNbS1Fgx+6g5fSzw14TCJwmw2iqiQ==",
       "license": "MIT"
     },
     "node_modules/@react-dnd/asap": {

--- a/projects/questionset-editor-react/package.json
+++ b/projects/questionset-editor-react/package.json
@@ -50,7 +50,7 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@project-sunbird/ckeditor-build-classic": "^4.1.3",
-    "@project-sunbird/sunbird-quml-player-web-component-react": "^0.1.2",
+    "@project-sunbird/sunbird-quml-player-web-component-react": "^0.1.3",
     "@tanstack/react-query": "^5.51.0",
     "@tiptap/extension-code-block": "^3.27.1",
     "@tiptap/extension-image": "^3.27.1",

--- a/projects/questionset-editor-react/src/api/asset.ts
+++ b/projects/questionset-editor-react/src/api/asset.ts
@@ -33,7 +33,7 @@ export async function searchAssets(params: {
 }): Promise<{ items: IAssetItem[]; count: number }> {
   // Old editor's questionService.getAssetMedia request shape.
   const filters: Record<string, unknown> = {
-    contentType: 'Asset',
+    primaryCategory: 'Asset',
     compatibilityLevel: { min: 1, max: 2 },
     status: ['Live'],
     mediaType: [params.mediaType],

--- a/projects/questionset-editor-react/src/components/QumlPlayer/QumlPlayer.tsx
+++ b/projects/questionset-editor-react/src/components/QumlPlayer/QumlPlayer.tsx
@@ -98,11 +98,17 @@ const QumlPlayer: React.FC<QumlPlayerProps> = ({ questionSetId, singleQuestionId
 
         if (singleQuestionId) {
           // Old question.component.previewContent single-question settings.
+          // The child is a bare reference — the player fetches the question
+          // body itself via question/v2/list (old editor behaviour); embedding
+          // tree metadata here would skip that call and render stale/empty
+          // content after a reload.
           const qNode = bfsFind(treeData, singleQuestionId);
           const qMeta = {
-            ...(qNode?.metadata ?? {}),
             identifier: singleQuestionId,
             name: qNode?.name ?? 'Question',
+            mimeType: 'application/vnd.sunbird.question',
+            objectType: 'Question',
+            visibility: 'Parent',
           };
           metadata = {
             ...metadata,

--- a/projects/questionset-editor-react/src/components/SplitEditorShell/SplitEditorShell.tsx
+++ b/projects/questionset-editor-react/src/components/SplitEditorShell/SplitEditorShell.tsx
@@ -76,7 +76,11 @@ export function SplitEditorShell({ events }: SplitEditorShellProps) {
         case 'sendForReview':
         case 'reject':
         case 'publish': {
-          await runAction(action, data);
+          // Old editor closes after a successful workflow action — emit
+          // 'back' so the host navigates away (portal returns to workspace).
+          if (await runAction(action, data)) {
+            events.onToolbarEvent?.({ action: 'back' });
+          }
           break;
         }
         default:

--- a/projects/questionset-editor-react/src/components/modals/PublishChecklist.module.scss
+++ b/projects/questionset-editor-react/src/components/modals/PublishChecklist.module.scss
@@ -41,16 +41,16 @@
   cursor: pointer;
   width: 100%;
   padding: var(--sbx-space-3) var(--sbx-space-4);
-  border-radius: var(--sbx-radius-lg);
-  border: 1px solid var(--sbx-color-border-default);
-  background-color: var(--sbx-color-surface-sunken);
+  border-radius: 14px;
+  border: 1.5px solid var(--sb-border);
+  background-color: #fff;
   transition:
     background-color var(--sbx-duration-base) var(--sbx-ease-default),
     border-color     var(--sbx-duration-base) var(--sbx-ease-default);
 
   &:hover {
-    background-color: var(--sbx-color-primary-subtle);
-    border-color: var(--sbx-color-primary);
+    background-color: var(--accent-soft);
+    border-color: var(--accent);
   }
 }
 
@@ -92,9 +92,9 @@
 }
 
 .customCheckChecked {
-  border-color: var(--sbx-color-primary);
-  background-color: var(--sbx-color-primary);
-  color: var(--sbx-color-primary-fg);
+  border-color: var(--accent);
+  background-color: var(--accent);
+  color: #fff;
 }
 
 // Item text

--- a/projects/questionset-editor-react/src/components/shared/Button.module.scss
+++ b/projects/questionset-editor-react/src/components/shared/Button.module.scss
@@ -24,14 +24,14 @@
   gap: var(--sbx-space-2);
   flex-shrink: 0;
 
-  // Typography
-  font-family: var(--sbx-font-sans);
-  font-weight: var(--sbx-font-medium);
+  // Typography — matches .ce-btn
+  font-family: var(--sb-font, var(--sbx-font-sans));
+  font-weight: 700;
   line-height: 1;
   white-space: nowrap;
 
-  // Shape
-  border-radius: var(--sbx-radius-md);
+  // Shape — matches .ce-btn
+  border-radius: 13px;
   border: 1px solid transparent;
 
   // Transition
@@ -61,36 +61,33 @@
 // Size variants
 // ---------------------------------------------------------------------------
 .button--sm {
-  padding: var(--sbx-space-1) var(--sbx-space-3);
-  font-size: var(--sbx-text-sm);
-  min-height: 32px;
+  padding: 0 14px;
+  font-size: 13.5px;
+  min-height: 38px;
 }
 
 .button--md {
-  padding: var(--sbx-space-2) var(--sbx-space-4);
-  font-size: var(--sbx-text-sm);
-  min-height: 40px;
+  padding: 0 18px;
+  font-size: 14px;
+  min-height: 44px;
 }
 
 // ---------------------------------------------------------------------------
 // Variant: Primary
 // ---------------------------------------------------------------------------
 .button--primary {
-  background-color: var(--sbx-color-primary);
-  border-color:     var(--sbx-color-primary);
-  color:            var(--sbx-color-primary-fg);
-  box-shadow:       var(--sbx-shadow-xs);
+  // matches .ce-btn.primary
+  background-color: var(--accent);
+  border-color:     var(--accent);
+  color:            #fff;
 
   &:hover:not(:disabled):not([aria-disabled='true']) {
-    background-color: var(--sbx-color-primary-hover);
-    border-color:     var(--sbx-color-primary-hover);
-    box-shadow:       var(--sbx-shadow-sm);
+    background-color: var(--accent-deep);
+    border-color:     var(--accent-deep);
   }
 
   &:active:not(:disabled):not([aria-disabled='true']) {
-    background-color: var(--sbx-color-primary-active);
-    border-color:     var(--sbx-color-primary-active);
-    box-shadow:       none;
+    background-color: var(--accent-deep);
     transform: translateY(1px);
   }
 }
@@ -99,17 +96,18 @@
 // Variant: Ghost
 // ---------------------------------------------------------------------------
 .button--ghost {
-  background-color: transparent;
-  border-color:     transparent;
-  color:            var(--sbx-color-text-secondary);
+  // matches .ce-btn.ghost
+  background-color: #fff;
+  border-color:     var(--sb-border);
+  color:            var(--sb-text-2);
 
   &:hover:not(:disabled):not([aria-disabled='true']) {
-    background-color: var(--sbx-color-surface-muted);
-    color:            var(--sbx-color-text-primary);
+    border-color: var(--accent);
+    color:        var(--accent-deep);
   }
 
   &:active:not(:disabled):not([aria-disabled='true']) {
-    background-color: var(--sbx-color-surface-dim);
+    border-color: var(--accent-deep);
   }
 }
 
@@ -117,20 +115,16 @@
 // Variant: Outline
 // ---------------------------------------------------------------------------
 .button--outline {
-  background-color: var(--sbx-color-surface-base);
-  border-color:     var(--sbx-color-border-default);
-  color:            var(--sbx-color-text-primary);
-  box-shadow:       var(--sbx-shadow-xs);
+  background-color: #fff;
+  border-color:     var(--sb-border);
+  color:            var(--sb-text);
 
   &:hover:not(:disabled):not([aria-disabled='true']) {
-    background-color: var(--sbx-color-surface-muted);
-    border-color:     var(--sbx-color-border-strong);
-    box-shadow:       var(--sbx-shadow-sm);
+    border-color: var(--accent);
+    color:        var(--accent-deep);
   }
 
   &:active:not(:disabled):not([aria-disabled='true']) {
-    background-color: var(--sbx-color-surface-dim);
-    box-shadow:       none;
     transform: translateY(1px);
   }
 }
@@ -139,20 +133,17 @@
 // Variant: Danger
 // ---------------------------------------------------------------------------
 .button--danger {
-  background-color: var(--sbx-color-error);
-  border-color:     var(--sbx-color-error);
-  color:            var(--sbx-color-error-fg);
-  box-shadow:       var(--sbx-shadow-xs);
+  // matches .ce-btn.danger (outline red)
+  background-color: #fff;
+  border-color:     var(--sb-red-border);
+  color:            var(--sb-red);
 
   &:hover:not(:disabled):not([aria-disabled='true']) {
-    background-color: var(--sbx-color-error-hover);
-    border-color:     var(--sbx-color-error-hover);
-    box-shadow:       var(--sbx-shadow-sm);
+    background-color: var(--sb-red-soft);
   }
 
   &:active:not(:disabled):not([aria-disabled='true']) {
-    filter: brightness(0.9);
-    box-shadow: none;
+    background-color: var(--sb-red-soft);
     transform: translateY(1px);
   }
 }

--- a/projects/questionset-editor-react/src/components/shared/Modal.module.scss
+++ b/projects/questionset-editor-react/src/components/shared/Modal.module.scss
@@ -15,9 +15,8 @@
   justify-content: center;
   padding: var(--sbx-space-4);
 
-  background-color: rgba(17, 24, 39, 0.55);   // neutral-900 @ 55%
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
+  background-color: rgba(0, 0, 0, 0.45);      // matches ConfirmDialog scrim
+  font-family: var(--sb-font, inherit);
 
   // Entry animation
   animation: sbx-overlay-in var(--sbx-duration-slow) var(--sbx-ease-out) both;
@@ -57,10 +56,11 @@
   max-width: 560px;
   max-height: calc(100dvh - var(--sbx-space-8));
 
-  background-color: var(--sbx-color-surface-raised);
-  border-radius:    var(--sbx-radius-xl);
-  box-shadow:       var(--sbx-shadow-xl);
-  border:           1px solid var(--sbx-color-border-subtle);
+  // Editor dialog theme (same surface as ConfirmDialog)
+  background-color: var(--sb-card, #fff);
+  border-radius:    18px;
+  box-shadow:       var(--sb-shadow-deep);
+  border:           none;
 
   overflow: hidden;
 
@@ -102,15 +102,14 @@
   justify-content: space-between;
   gap: var(--sbx-space-3);
 
-  padding: var(--sbx-space-4) var(--sbx-space-6);
-  border-bottom: 1px solid var(--sbx-color-border-subtle);
+  padding: 20px 24px 16px;
   flex-shrink: 0;
 }
 
 .title {
-  font-size:   var(--sbx-text-lg);
-  font-weight: var(--sbx-font-semibold);
-  color:       var(--sbx-color-text-primary);
+  font-size:   18px;
+  font-weight: 800;
+  color:       var(--sb-text);
   line-height: var(--sbx-leading-snug);
   margin: 0;
 }
@@ -152,7 +151,9 @@
   flex: 1 1 auto;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: var(--sbx-space-6);
+  padding: 0 24px 24px;
+  font-size: 15px;
+  color: var(--sb-text-2);
 
   // Subtle inset shadow when content overflows
   scroll-padding-block: var(--sbx-space-4);
@@ -176,8 +177,8 @@
   justify-content: flex-end;
   gap: var(--sbx-space-3);
 
-  padding: var(--sbx-space-4) var(--sbx-space-6);
-  border-top: 1px solid var(--sbx-color-border-subtle);
-  background-color: var(--sbx-color-surface-sunken);
+  padding: 16px 24px;
+  border-top: 1px solid var(--sb-border);
+  background-color: transparent;
   flex-shrink: 0;
 }

--- a/projects/questionset-editor-react/src/utils/notify.ts
+++ b/projects/questionset-editor-react/src/utils/notify.ts
@@ -1,4 +1,18 @@
 import toast from 'react-hot-toast';
+import { createElement } from 'react';
+
+// Static icon — react-hot-toast's animated checkmark/error icons rely on
+// delayed CSS keyframes that host-page styles can interrupt, leaving the
+// intermediate spinner arc on screen.
+function statusIcon(background: string, glyph: string) {
+  return createElement('span', {
+    style: {
+      display: 'grid', placeItems: 'center', flex: 'none',
+      width: 20, height: 20, borderRadius: '50%',
+      background, color: '#fff', fontSize: 12, fontWeight: 800, lineHeight: 1,
+    },
+  }, glyph);
+}
 
 // One consistent look for every API success/failure notification —
 // themed like the app's cards (sb tokens), top-right via the shared Toaster.
@@ -18,7 +32,7 @@ const baseStyle: React.CSSProperties = {
 export function notifySuccess(message: string): void {
   toast.success(message, {
     style: baseStyle,
-    iconTheme: { primary: 'var(--accent, #16a34a)', secondary: '#fff' },
+    icon: statusIcon('var(--sb-green, #16a34a)', '✓'),
   });
 }
 
@@ -26,7 +40,7 @@ export function notifyError(message: string): void {
   toast.error(message, {
     style: baseStyle,
     duration: 5000,
-    iconTheme: { primary: 'var(--sb-red, #dc2626)', secondary: '#fff' },
+    icon: statusIcon('var(--sb-red, #dc2626)', '✕'),
   });
   // Old editor logs an ERROR telemetry event for surfaced failures.
   void import('./telemetry').then(({ telemetryError }) => telemetryError(message));


### PR DESCRIPTION
### Summary

Bug fixes for the React QuestionSet editor web component, addressing issues found while integrating the published package into the Sunbird Spark portal.

**API parity fixes**
- **Asset search** — composite search for the image/video/audio pickers now filters by `primaryCategory: "Asset"` instead of `contentType: "Asset"`, so assets created through the editor (which are created with `primaryCategory: 'Asset'`) appear in My/All listings.

**Preview (QuML player) fixes**
- **Single-question preview fetches via `question/v2/list`** — the player config now passes a bare child reference (identifier/name/mimeType) instead of embedding tree metadata, letting the player fetch the question body itself exactly like the old editor's question-preview flow. Also fixes empty previews after a page reload, when local tree metadata doesn't carry the body.
- **No global player stylesheet injection** — the editor no longer links `sunbird-quml-player-styles.css` into `document.head`. The React player is fully self-styled inside its shadow DOM, and the external file's unscoped global reset (`*, *:before, *:after`) was leaking into and breaking the editor layout once a preview had been opened.

**Workflow fixes**
- **Editor closes after a successful workflow action** — Send for Review, Reject and Publish now emit `back` to the host on success (old-editor behaviour), so the portal navigates back to the workspace. On failure the editor stays open with the error toast.

**UI/theme fixes**
- **Modal + button primitives rethemed** to the editor's dialog design (white card, 18px radius, themed footer, `.ce-btn`-style primary/ghost/danger variants) — fixes the off-theme Publish checklist and Reject dialogs.
- **Publish checklist rows** restyled to theme tokens (accent hover/checked state instead of the yellow highlight).
- **Static toast icons** — success/error notifications use fixed ✓/✕ icons; react-hot-toast's animated checkmark could get stuck on its intermediate spinner arc under host-page CSS.

**Dependencies**
- Replaced hand-rolled UUID helpers with the `uuid` package (same as the Angular editor) for asset `code` and node/solution/hint id generation.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

- [x] Manual end-to-end testing against test.sunbirded.org through the Sunbird Spark portal integration: asset upload + search listing, single-question and full-set previews, send-for-review/publish/reject flows, dialog theming
- [x] `tsc` type-check and Vitest suite pass locally

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
