### PR TITLE
Enhance layout, theming, and input handling

### DIFF
--- a/projects/questionset-editor-react/package.json
+++ b/projects/questionset-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-questionset-editor-web-component-react",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "React-based QuML QuestionSet Editor — usable as a React component or as a <sb-questionset-editor> web component in any framework.",
   "keywords": [
     "sunbird",

--- a/projects/questionset-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
+++ b/projects/questionset-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
@@ -137,12 +137,32 @@ const ContextualEditor: React.FC<ContextualEditorProps> = ({
   }, [onToolbarEvent]);
 
   const licenses = useEditorStore((s) => s.licenses);
-  // Old meta-form fills the license field's options from getLicenses().
+  // Old meta-form fills the license field's options from getLicenses(), and
+  // the section's maxQuestions dropdown offers 1..N where N is the number of
+  // questions currently in the section (old editor behaviour).
+  const questionCount = useTreeStore((s) => {
+    const node = s.selectedNodeId ? bfs(s.treeData, s.selectedNodeId) : undefined;
+    return (node?.children ?? []).filter((c) => c.isQuestion).length;
+    function bfs(nodes: typeof s.treeData, id: string) {
+      const q = [...nodes];
+      while (q.length) {
+        const n = q.shift()!;
+        if (n.id === id || n.identifier === id) return n;
+        if (n.children) q.push(...n.children);
+      }
+      return undefined;
+    }
+  });
   const withLicenseOptions = useCallback(
     (fields: typeof rootFormConfig) =>
-      (fields ?? []).map((f) =>
-        f.code === 'license' && !f.range && licenses.length ? { ...f, range: licenses } : f),
-    [licenses],
+      (fields ?? []).map((f) => {
+        if (f.code === 'license' && !f.range && licenses.length) return { ...f, range: licenses };
+        if (f.code === 'maxQuestions') {
+          return { ...f, range: Array.from({ length: questionCount }, (_, i) => String(i + 1)) };
+        }
+        return f;
+      }),
+    [licenses, questionCount],
   );
 
   const formConfig = isCurrentNodeRoot ? rootFormConfig : unitFormConfig;

--- a/projects/questionset-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
+++ b/projects/questionset-editor-react/src/components/ContextualEditor/ContextualEditor.tsx
@@ -140,19 +140,11 @@ const ContextualEditor: React.FC<ContextualEditorProps> = ({
   // Old meta-form fills the license field's options from getLicenses(), and
   // the section's maxQuestions dropdown offers 1..N where N is the number of
   // questions currently in the section (old editor behaviour).
-  const questionCount = useTreeStore((s) => {
-    const node = s.selectedNodeId ? bfs(s.treeData, s.selectedNodeId) : undefined;
-    return (node?.children ?? []).filter((c) => c.isQuestion).length;
-    function bfs(nodes: typeof s.treeData, id: string) {
-      const q = [...nodes];
-      while (q.length) {
-        const n = q.shift()!;
-        if (n.id === id || n.identifier === id) return n;
-        if (n.children) q.push(...n.children);
-      }
-      return undefined;
-    }
-  });
+  const questionCount = useTreeStore((s) =>
+    s.selectedNodeId
+      ? s.getChildrenOf(s.selectedNodeId).filter((c) => c.isQuestion).length
+      : 0,
+  );
   const withLicenseOptions = useCallback(
     (fields: typeof rootFormConfig) =>
       (fields ?? []).map((f) => {

--- a/projects/questionset-editor-react/src/components/QuestionEditor/BooleanEditor/BooleanEditor.tsx
+++ b/projects/questionset-editor-react/src/components/QuestionEditor/BooleanEditor/BooleanEditor.tsx
@@ -51,7 +51,7 @@ export default function BooleanEditor({ readOnly = false }: BooleanEditorProps) 
         {options.map(o => (
           <div key={o.id} className={`ce-opt${o.isCorrect ? ' correct' : ''}`}>
             <button type="button" className="pick" title="Mark correct" onClick={() => !readOnly && markCorrect(o.id)}>
-              <span className="ring">{o.isCorrect && <Icon name="check" size={12} />}</span>
+              <span className="pick-ring">{o.isCorrect && <Icon name="check" size={12} />}</span>
             </button>
             <div className="re">
               <ContentEditable

--- a/projects/questionset-editor-react/src/components/QuestionEditor/McqEditor/McqEditor.tsx
+++ b/projects/questionset-editor-react/src/components/QuestionEditor/McqEditor/McqEditor.tsx
@@ -47,7 +47,7 @@ export default function McqEditor({ readOnly = false }: McqEditorProps) {
         {options.map(o => (
           <div key={o.id} className={`ce-opt${o.isCorrect ? ' correct' : ''}`}>
             <button type="button" className="pick" title="Mark correct" onClick={() => !readOnly && markCorrect(o.id)}>
-              <span className="ring">{o.isCorrect && <Icon name="check" size={12} />}</span>
+              <span className="pick-ring">{o.isCorrect && <Icon name="check" size={12} />}</span>
             </button>
             <div className="re">
               <ContentEditable

--- a/projects/questionset-editor-react/src/components/QuestionEditor/QuestionEditor.tsx
+++ b/projects/questionset-editor-react/src/components/QuestionEditor/QuestionEditor.tsx
@@ -299,10 +299,14 @@ export default function QuestionEditor({ editorMode, onBack }: QuestionEditorPro
   // Validation runs against the PRIMARY language (en) — other languages are
   // optional translations (old editor semantics). When editing a non-en
   // language, the en text lives in the i18n maps.
-  const contentLang = useQuestionStore((st) => st.contentLang);
   const i18nText = useQuestionStore((st) => st.i18nText);
-  const enOf = (map: Record<string, string> | undefined, current: string) =>
-    contentLang === 'en' ? current : (map?.en ?? '');
+  // A field is "filled" when it has content in the visible language OR any
+  // authored language — questions may be authored in a non-English language
+  // only (old editor allowed this; English is not mandatory).
+  const anyOf = (map: Record<string, string> | undefined, current: string) => {
+    if (plain(current)) return current;
+    return Object.values(map ?? {}).find((v) => plain(v)) ?? '';
+  };
   
   // Details form (childMetadata) — writes into the tree node like the tab did.
   const questionFormConfig = useEditorStore((st) => st.questionFormConfig);
@@ -322,9 +326,8 @@ export default function QuestionEditor({ editorMode, onBack }: QuestionEditorPro
   const [detailsValid, setDetailsValid] = useState(true);
 
   const invalidReason = (() => {
-    const qBody = enOf(i18nText.questionBody, questionBody);
-    if (!plain(qBody)) return 'Enter the question first (in EN)';
-    if (!plain(questionBody)) return 'Enter the question first';
+    const qBody = anyOf(i18nText.questionBody, questionBody);
+    if (!plain(qBody)) return 'Enter the question first';
     // Title and Marks come from the Details section — no defaults.
     if (!String((activeNodeMeta?.name as string) ?? '').trim()) {
       return 'Enter the title in Details';
@@ -336,31 +339,31 @@ export default function QuestionEditor({ editorMode, onBack }: QuestionEditorPro
     switch (type) {
       case 'mcq':
       case 'boolean':
-        if (options.some((o) => !plain(enOf(i18nText.options[o.id], o.body)))) return 'Fill in all options (in EN)';
+        if (options.some((o) => !plain(anyOf(i18nText.options[o.id], o.body)))) return 'Fill in all options';
         if (!options.some((o) => o.isCorrect)) return 'Mark one option as the correct answer';
         return null;
       case 'ftb':
         if (!/\[\[.+?\]\]/.test(qBody)) return 'Add at least one [[blank]] with its answer';
         return null;
       case 'sa':
-        if (!plain(enOf(i18nText.answerText, answerText))) return 'Enter the answer (in EN)';
+        if (!plain(anyOf(i18nText.answerText, answerText))) return 'Enter the answer';
         return null;
       case 'mtf':
         if (
           matchPairs.length < 2 ||
-          matchPairs.some((p) => !plain(enOf(i18nText.pairsLeft[p.id], p.left)) || !plain(enOf(i18nText.pairsRight[p.id], p.right)))
+          matchPairs.some((p) => !plain(anyOf(i18nText.pairsLeft[p.id], p.left)) || !plain(anyOf(i18nText.pairsRight[p.id], p.right)))
         ) {
-          return 'Fill in all matching pairs (in EN)';
+          return 'Fill in all matching pairs';
         }
         return null;
       case 'seq':
-        if (sequence.length < 2 || sequence.some((s, i) => !plain(enOf(i18nText.sequence[i], s)))) {
-          return 'Fill in all sequence items (in EN)';
+        if (sequence.length < 2 || sequence.some((s, i) => !plain(anyOf(i18nText.sequence[i], s)))) {
+          return 'Fill in all sequence items';
         }
         return null;
       case 'reo':
-        if (plain(enOf(i18nText.sentence, sentence)).split(/\s+/).filter(Boolean).length < 2) {
-          return 'Enter a sentence with at least two words (in EN)';
+        if (plain(anyOf(i18nText.sentence, sentence)).split(/\s+/).filter(Boolean).length < 2) {
+          return 'Enter a sentence with at least two words';
         }
         return null;
       default:

--- a/projects/questionset-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
+++ b/projects/questionset-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
@@ -65,6 +65,72 @@ function hmsToSeconds(hms: string): number {
   return Number(hms) || 0;
 }
 
+// HH:mm timer input — keeps the typed digits in local state; committing on
+// every keystroke and re-deriving from seconds would zero-pad ("1" → "01"),
+// hit maxLength and block the second digit.
+function TimerHmsField({ seconds, disabled, onCommit, onBlur }: {
+  seconds: number;
+  disabled?: boolean;
+  onCommit: (secs: number) => void;
+  onBlur?: () => void;
+}) {
+  const [hh, setHh] = useState('');
+  const [mm, setMm] = useState('');
+
+  const localSecs = (h: string, m: string) =>
+    hmsToSeconds(`${(h || '0').padStart(2, '0')}:${(m || '0').padStart(2, '0')}:00`);
+
+  // Re-sync only when the committed value changed externally (hydration/reset).
+  useEffect(() => {
+    if (localSecs(hh, mm) !== seconds) {
+      const parts = secondsToHms(seconds).split(':');
+      setHh(parts[0] === '00' ? '' : (parts[0] ?? ''));
+      setMm(parts[1] === '00' ? '' : (parts[1] ?? ''));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [seconds]);
+
+  const change = (h: string, m: string) => {
+    setHh(h);
+    setMm(m);
+    onCommit(localSecs(h, m));
+  };
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <input
+        type="text" maxLength={2} placeholder="HH"
+        className={styles.input}
+        style={{ width: 72, textAlign: 'center' }}
+        value={hh}
+        onChange={e => change(e.target.value.replace(/\D/g, ''), mm)}
+        onBlur={onBlur}
+        disabled={disabled}
+      />
+      <span style={{ fontWeight: 700, color: 'var(--sb-text-muted)', fontSize: 18 }}>:</span>
+      <input
+        type="text" maxLength={2} placeholder="mm"
+        className={styles.input}
+        style={{ width: 72, textAlign: 'center' }}
+        value={mm}
+        onChange={e => change(hh, e.target.value.replace(/\D/g, ''))}
+        onBlur={onBlur}
+        disabled={disabled}
+      />
+      {!disabled && (
+        <button
+          type="button"
+          onClick={() => change('', '')}
+          className="ce-btn ghost"
+          style={{ height: 38, padding: '0 14px', fontSize: 13 }}
+        >
+          Reset
+        </button>
+      )}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Types for range items (framework-driven options)
 // ---------------------------------------------------------------------------
@@ -477,13 +543,18 @@ const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
         const isDisabled = readOnly || !field.editable;
         const validator = makeFieldValidator(field);
 
-        // Full-width: textarea, richtext, keywords/chips, multiselect, checkbox, time, appIcon
-        const isFullWidth = ['textarea', 'richtext', 'keywords', 'checkbox', 'time', 'appIcon'].includes(field.inputType ?? '')
-          || field.span === 'full';
-        const fieldClass = [styles.field, isFullWidth ? styles.fieldFull : ''].filter(Boolean).join(' ');
-
-        // showTimer: separator above
+        // showTimer: separator above, keeps its own full row
         const isShowTimer = field.code === 'showTimer';
+
+        // Full-width: textarea, richtext, keywords/chips, time, appIcon.
+        // Checkboxes flow two per row in the grid.
+        const isFullWidth = ['textarea', 'richtext', 'keywords', 'time', 'appIcon'].includes(field.inputType ?? '')
+          || field.span === 'full'
+          || isShowTimer
+          // Count select takes its own row — only the behaviour checkboxes
+          // (shuffle/feedback/solution/hint) flow two per row.
+          || field.code === 'maxQuestions';
+        const fieldClass = [styles.field, isFullWidth ? styles.fieldFull : ''].filter(Boolean).join(' ');
         // Checkboxes (and showTimer's custom row) carry their label inline —
         // a separate uppercase header would duplicate it.
         const hideLabel = isShowTimer || field.inputType === 'checkbox';
@@ -688,48 +759,13 @@ const SparkMetaForm: React.FC<SparkMetaFormProps> = ({
 
                 // ── timer — HH : mm split inputs ─────────────────────────
                 if (inputType === 'timepicker' || inputType === 'timer' || field.code === 'maxTime' || field.code === 'warningTime') {
-                  const numVal = Number(rhfField.value) || 0;
-                  const hms    = secondsToHms(numVal).split(':');
-                  const hh = hms[0] ?? '00';
-                  const mm = hms[1] ?? '00';
-                  const update = (newHH: string, newMM: string) => {
-                    const secs = hmsToSeconds(`${newHH.padStart(2,'0')}:${newMM.padStart(2,'0')}:00`);
-                    rhfField.onChange(secs);
-                    onChange(field.code, secs);
-                  };
-                  const reset = () => { rhfField.onChange(0); onChange(field.code, 0); };
                   return (
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                      <input
-                        type="text" maxLength={2} placeholder="HH"
-                        className={styles.input}
-                        style={{ width: 72, textAlign: 'center' }}
-                        value={hh === '00' ? '' : hh}
-                        onChange={e => update(e.target.value.replace(/\D/g,''), mm)}
-                        onBlur={rhfField.onBlur}
-                        disabled={isDisabled}
-                      />
-                      <span style={{ fontWeight: 700, color: 'var(--sb-text-muted)', fontSize: 18 }}>:</span>
-                      <input
-                        type="text" maxLength={2} placeholder="mm"
-                        className={styles.input}
-                        style={{ width: 72, textAlign: 'center' }}
-                        value={mm === '00' ? '' : mm}
-                        onChange={e => update(hh, e.target.value.replace(/\D/g,''))}
-                        onBlur={rhfField.onBlur}
-                        disabled={isDisabled}
-                      />
-                      {!isDisabled && (
-                        <button
-                          type="button"
-                          onClick={reset}
-                          className="ce-btn ghost"
-                          style={{ height: 38, padding: '0 14px', fontSize: 13 }}
-                        >
-                          Reset
-                        </button>
-                      )}
-                    </div>
+                    <TimerHmsField
+                      seconds={Number(rhfField.value) || 0}
+                      disabled={isDisabled}
+                      onCommit={(secs) => { rhfField.onChange(secs); onChange(field.code, secs); }}
+                      onBlur={rhfField.onBlur}
+                    />
                   );
                 }
 

--- a/projects/questionset-editor-react/src/components/SplitEditorShell/SplitEditorShell.tsx
+++ b/projects/questionset-editor-react/src/components/SplitEditorShell/SplitEditorShell.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { EditorRootContext } from '../shared/EditorRootContext';
 import type { IEditorEvents, ToolbarAction } from '../../types/editor';
 import { useTreeStore } from '../../store/tree.store';
 import { useEditorStore } from '../../store/editor.store';
@@ -109,8 +110,14 @@ export function SplitEditorShell({ events }: SplitEditorShellProps) {
   const questionEditorOpen = useUiStore((s) => s.questionEditorOpen);
   const hasContent = useTreeStore((s) => s.treeData.length > 0);
 
+  // Own root element — modals portal into THIS instance's .ce (multiple
+  // editors can be mounted on one host page; a global querySelector would
+  // always hit the first).
+  const [rootEl, setRootEl] = useState<HTMLElement | null>(null);
+
   return (
-    <div className="ce">
+    <EditorRootContext.Provider value={rootEl}>
+    <div className="ce" ref={setRootEl}>
       {/* Top bar */}
       <Topbar
         disabled={questionEditorOpen}
@@ -167,6 +174,7 @@ export function SplitEditorShell({ events }: SplitEditorShellProps) {
       <QuestionTypeSelectorModal />
       <ConnectedConfirmDialog />
     </div>
+    </EditorRootContext.Provider>
   );
 }
 

--- a/projects/questionset-editor-react/src/components/shared/EditorRootContext.ts
+++ b/projects/questionset-editor-react/src/components/shared/EditorRootContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+/**
+ * The owning editor instance's `.ce` root element. Modals portal into it so
+ * the `--sb-*`/`--accent` variables (scoped to `.ce`) apply — a global
+ * `document.querySelector('.ce')` would resolve to the FIRST editor on the
+ * page, which is wrong when a host mounts multiple instances.
+ */
+export const EditorRootContext = createContext<HTMLElement | null>(null);

--- a/projects/questionset-editor-react/src/components/shared/Modal.tsx
+++ b/projects/questionset-editor-react/src/components/shared/Modal.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useCallback, useRef } from 'react';
+import React, { useEffect, useCallback, useRef, useContext } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
+import { EditorRootContext } from './EditorRootContext';
 import styles from './Modal.module.scss';
 
 // -----------------------------------------------------------------------------
@@ -110,11 +111,13 @@ const Modal: React.FC<ModalProps> = ({
     .filter(Boolean)
     .join(' ');
 
-  // Portal into the editor root when present — the sb/accent CSS variables
-  // are scoped to .ce, so a body-level portal loses the theme (e.g. the
-  // checked checkbox renders white-on-white).
+  // Portal into the OWNING editor instance's .ce root (via context) — the
+  // sb/accent CSS variables are scoped to .ce, so a body-level portal loses
+  // the theme, and a global querySelector('.ce') would resolve to the first
+  // editor instance on the page, not necessarily this one.
+  const editorRoot = useContext(EditorRootContext);
   const portalTarget =
-    container ?? (typeof document !== 'undefined'
+    container ?? editorRoot ?? (typeof document !== 'undefined'
       ? (document.querySelector('.ce') ?? document.body)
       : null);
 

--- a/projects/questionset-editor-react/src/components/shared/Modal.tsx
+++ b/projects/questionset-editor-react/src/components/shared/Modal.tsx
@@ -110,8 +110,13 @@ const Modal: React.FC<ModalProps> = ({
     .filter(Boolean)
     .join(' ');
 
+  // Portal into the editor root when present — the sb/accent CSS variables
+  // are scoped to .ce, so a body-level portal loses the theme (e.g. the
+  // checked checkbox renders white-on-white).
   const portalTarget =
-    container ?? (typeof document !== 'undefined' ? document.body : null);
+    container ?? (typeof document !== 'undefined'
+      ? (document.querySelector('.ce') ?? document.body)
+      : null);
 
   if (!portalTarget) return null;
 

--- a/projects/questionset-editor-react/src/styles/_collection.scss
+++ b/projects/questionset-editor-react/src/styles/_collection.scss
@@ -149,7 +149,10 @@
 .ce-tree-foot button svg { color: var(--accent); }
 
 /* ── Center detail ──────────────────────────────────────────── */
-.ce-main { flex: 1; min-width: 0; display: flex; flex-direction: column; min-height: 0; }
+/* Defensive: host pages target the semantic <main>/<aside> elements with
+   width/centering rules — pin ours so the editor pane always fills. */
+.ce-main { flex: 1; min-width: 0; max-width: none; margin: 0; padding: 0; display: flex; flex-direction: column; min-height: 0; }
+aside.ce-tree { max-width: none; margin: 0; }
 .ce-crumb { flex: none; display: flex; align-items: center; gap: 9px; padding: 16px 28px 4px; font-size: 13.5px; color: var(--sb-text-muted); }
 .ce-crumb button { display: inline-flex; align-items: center; gap: 7px; border: none; background: transparent; cursor: pointer; font-family: inherit; font-size: 13.5px; font-weight: 600; color: var(--sb-text-muted); padding: 3px 4px; border-radius: 7px; }
 .ce-crumb button:hover { color: var(--accent-deep); }
@@ -157,7 +160,10 @@
 .ce-crumb .sep { color: var(--sb-text-faint); display: grid; place-items: center; }
 .ce-main-scroll { flex: 1; overflow: auto; padding: 12px 28px 60px; }
 .ce-card {
-  max-width: 940px; margin: 0 auto; background: var(--sb-card);
+  /* Fill the pane up to 940px, never collapse below a usable width on
+     normal screens, and stay responsive below 640px. */
+  width: 100%; min-width: min(640px, 100%); max-width: 940px; margin: 0 auto;
+  background: var(--sb-card);
   border: 1px solid var(--sb-border-soft); border-radius: 22px; box-shadow: var(--sb-shadow-card);
   overflow: hidden;
 }
@@ -310,7 +316,7 @@
 @keyframes ce-spin { to { transform: rotate(360deg); } }
 
 /* ── Question editor (when opened inline) ────────────────────── */
-.ce-ed { max-width: 940px; margin: 0 auto; }
+.ce-ed { width: 100%; min-width: min(640px, 100%); max-width: 940px; margin: 0 auto; }
 .ce-ed-back { display: inline-flex; align-items: center; gap: 8px; border: none; background: transparent; cursor: pointer; font-family: inherit; font-size: 13.5px; font-weight: 700; color: var(--sb-text-muted); padding: 6px 8px; border-radius: 9px; margin-bottom: 12px; }
 .ce-ed-back:hover { color: var(--accent-deep); background: var(--accent-soft); }
 /* overflow:clip preserves border-radius visual clipping but does NOT break position:sticky (unlike overflow:hidden) */
@@ -351,8 +357,10 @@
 .ce-opt { display: flex; align-items: center; gap: 12px; padding: 6px 12px 6px 6px; border: 1.5px solid var(--sb-border); border-radius: 14px; background: #fff; margin-bottom: 11px; transition: border-color .14s, background .14s; }
 .ce-opt.correct { border-color: var(--sb-green); background: var(--sb-green-soft); }
 .ce-opt .pick { width: 38px; height: 38px; flex: none; border-radius: 10px; border: none; background: transparent; cursor: pointer; display: grid; place-items: center; color: var(--sb-text-faint); }
-.ce-opt .pick .ring { width: 22px; height: 22px; border-radius: 50%; border: 2px solid var(--sb-border); display: grid; place-items: center; color: #fff; transition: all .14s; }
-.ce-opt.correct .pick .ring { border-color: var(--sb-green); background: var(--sb-green); }
+/* .pick-ring, not .ring — the host portal's Tailwind build ships a global
+   `.ring` utility (blue box-shadow) that collides with the bare name. */
+.ce-opt .pick .pick-ring { width: 22px; height: 22px; border-radius: 50%; border: 2px solid var(--sb-border); display: grid; place-items: center; color: #fff; transition: all .14s; }
+.ce-opt.correct .pick .pick-ring { border-color: var(--sb-green); background: var(--sb-green); }
 .ce-opt .grip { border: none; background: transparent; color: var(--sb-text-faint); cursor: grab; flex: none; display: grid; place-items: center; padding: 0; }
 .ce-opt .re { flex: 1; min-width: 0; }
 .ce-opt .del { width: 34px; height: 34px; flex: none; border-radius: 9px; border: none; background: transparent; color: var(--sb-text-faint); cursor: pointer; display: grid; place-items: center; }


### PR DESCRIPTION
### Summary

UI fixes for the React QuestionSet editor when hosted inside the Sunbird Spark portal (light-DOM rendering exposes the editor to the host page's global styles), plus form input/behaviour corrections. Includes a package version bump for release.

**Host-page CSS resilience**
- **Layout hardening** — `.ce-main`/`aside.ce-tree` pin `max-width`/`margin` so host rules targeting the semantic `<main>`/`<aside>` elements can't center or cap the editor pane; `.ce-card` and `.ce-ed` are now `width: 100%; min-width: min(640px, 100%); max-width: 940px`, so the content card fills the pane, never collapses on normal screens, and shrinks gracefully below 640px viewports.
- **Tailwind `ring` collision** — the MCQ/Boolean option radio span was named `ring`, which collides with the host portal's compiled Tailwind `.ring` utility (blue `box-shadow` halo). Renamed to `pick-ring`.
- **Modal theming scope** — the shared `Modal` now portals into the `.ce` editor root instead of `document.body`. The `--accent`/`--sb-*` CSS variables are scoped to `.ce`, so body-level dialogs lost the theme (white-on-white Publish button, vanishing checked checkboxes in the publish checklist).

**Form fixes**
- **HH:mm timer input** — typed digits are kept in local state (`TimerHmsField`); previously each keystroke was committed as seconds and re-rendered zero-padded ("1" → "01"), hitting `maxLength=2` and blocking double-digit hours/minutes.
- **Section `maxQuestions` dropdown** — "Count of questions to be displayed" now offers `1..N` where N is the live number of questions in the selected section (old-editor behaviour), instead of an empty option list.
- **Behaviour checkboxes in a grid** — Shuffle Questions / Show Question Feedback / Show Solution / Show Hint flow two per row; the count select and `showTimer` keep their own full rows.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

- [x] Manual verification inside the Sunbird Spark portal (test.sunbirded.org backend): editor layout with previews open/closed, publish checklist theming, MCQ option styling, timer input entry, section behaviour tab
- [x] `tsc` type-check and Vitest suite pass locally

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
