### PR TITLE
Fix metadata key and center loading/error text overlay

### DIFF
--- a/projects/questionset-editor-react/package-lock.json
+++ b/projects/questionset-editor-react/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@project-sunbird/sunbird-questionset-editor-web-component-react",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-sunbird/sunbird-questionset-editor-web-component-react",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@project-sunbird/ckeditor-build-classic": "^4.1.3",
-        "@project-sunbird/sunbird-quml-player-web-component-react": "0.1.6",
+        "@project-sunbird/sunbird-quml-player-web-component-react": "0.1.7",
         "@tanstack/react-query": "^5.51.0",
         "@tiptap/extension-code-block": "^3.27.1",
         "@tiptap/extension-image": "^3.27.1",
@@ -1747,9 +1747,9 @@
       }
     },
     "node_modules/@project-sunbird/sunbird-quml-player-web-component-react": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component-react/-/sunbird-quml-player-web-component-react-0.1.6.tgz",
-      "integrity": "sha512-EUpuOBvXLS+g+LzqRnFGaurgbzMFSJFZI0/KyW2WHxO8RUfMrEDBMPGvTj5wMX9bu5jyb+4wQl7+qrO6CRujaw==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@project-sunbird/sunbird-quml-player-web-component-react/-/sunbird-quml-player-web-component-react-0.1.7.tgz",
+      "integrity": "sha512-ZyZyc7K2H0CAZbl0QGF2NhOLXBJx98RFOo4PV5t46mcCt9bWSej4h3AktDbhqtmYSujEIisbethLQ9GEVvsPHg==",
       "license": "MIT"
     },
     "node_modules/@react-dnd/asap": {

--- a/projects/questionset-editor-react/package.json
+++ b/projects/questionset-editor-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-questionset-editor-web-component-react",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "React-based QuML QuestionSet Editor — usable as a React component or as a <sb-questionset-editor> web component in any framework.",
   "keywords": [
     "sunbird",
@@ -51,7 +51,7 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@project-sunbird/ckeditor-build-classic": "^4.1.3",
-    "@project-sunbird/sunbird-quml-player-web-component-react": "0.1.6",
+    "@project-sunbird/sunbird-quml-player-web-component-react": "0.1.7",
     "@tanstack/react-query": "^5.51.0",
     "@tiptap/extension-code-block": "^3.27.1",
     "@tiptap/extension-image": "^3.27.1",

--- a/projects/questionset-editor-react/src/components/QumlPlayer/QumlPlayer.module.scss
+++ b/projects/questionset-editor-react/src/components/QumlPlayer/QumlPlayer.module.scss
@@ -60,6 +60,7 @@
 }
 
 .playerContainer {
+  position: relative;
   flex: 1 1 0;
   padding: 20px;
   display: flex;
@@ -69,7 +70,9 @@
 
   // Centered desktop-width card — wide enough for the player's landscape
   // layout, but bounded so options/nav controls stay inside the preview.
-  > div {
+  // Scoped to this class (not a generic `> div`) so the status overlay,
+  // which is also a direct div child, isn't drawn as a second white box.
+  .playerHost {
     width: 100%;
     max-width: 1000px;
     position: relative;
@@ -83,6 +86,17 @@
     width: 100%;
     height: 100%;
   }
+}
+
+.statusOverlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  pointer-events: none;
 }
 
 .playerPreview {

--- a/projects/questionset-editor-react/src/components/QumlPlayer/QumlPlayer.tsx
+++ b/projects/questionset-editor-react/src/components/QumlPlayer/QumlPlayer.tsx
@@ -193,23 +193,25 @@ const QumlPlayer: React.FC<QumlPlayerProps> = ({ questionSetId, singleQuestionId
   }, [onClose]);
 
   // Status messages live OUTSIDE the manually-managed host div — the player
-  // is appended imperatively and must not fight React's children.
-  const statusEl = (
-    <>
+  // is appended imperatively and must not fight React's children. Rendered
+  // as an absolutely-centered overlay so it never sits beside the (empty,
+  // but already-styled) host box as a flex sibling.
+  const statusEl = status === 'loading' || status === 'error' ? (
+    <div className={styles.statusOverlay}>
       {status === 'loading' && (
-        <p style={{ textAlign: 'center', color: '#888', padding: 40, margin: 0 }}>{L('ui.loadingPreview', 'Loading preview…')}</p>
+        <p style={{ color: '#888', margin: 0 }}>{L('ui.loadingPreview', 'Loading preview…')}</p>
       )}
       {status === 'error' && (
-        <p style={{ textAlign: 'center', color: '#c33', padding: 40, margin: 0 }}>
+        <p style={{ color: '#c33', margin: 0 }}>
           {L('ui.previewUnavailable', 'Could not load the QuML player. Please try again.')}
         </p>
       )}
-    </>
-  );
+    </div>
+  ) : null;
 
   if (inline) {
     return (
-      <div style={{ minHeight: status === 'ready' ? 420 : undefined }}>
+      <div style={{ position: 'relative', minHeight: status === 'ready' ? 420 : undefined }}>
         {statusEl}
         <div ref={hostRef} />
       </div>
@@ -235,7 +237,7 @@ const QumlPlayer: React.FC<QumlPlayerProps> = ({ questionSetId, singleQuestionId
       <div className={styles.playerContainer}>
         {statusEl}
         {/* Full width/height so the player lays out in desktop mode */}
-        <div ref={hostRef} style={{ width: '100%', height: '100%' }} />
+        <div ref={hostRef} className={styles.playerHost} style={{ height: '100%' }} />
       </div>
     </div>
   );

--- a/projects/questionset-editor-react/src/components/SectionBehaviourForm/SectionBehaviourForm.tsx
+++ b/projects/questionset-editor-react/src/components/SectionBehaviourForm/SectionBehaviourForm.tsx
@@ -16,7 +16,7 @@ const SectionBehaviourForm: React.FC<SectionBehaviourFormProps> = ({ nodeId, rea
   const shuffle       = (meta.shuffle       as boolean) ?? true;
   const showFeedback  = (meta.showFeedback  as boolean) ?? false;
   const showSolutions = (meta.showSolutions as boolean) ?? false;
-  const showHint      = (meta.showHint      as boolean) ?? false;
+  const showHints     = (meta.showHints     as boolean) ?? false;
 
   const patch = useCallback((key: string, value: unknown) => {
     if (!nodeId) return;
@@ -58,8 +58,8 @@ const SectionBehaviourForm: React.FC<SectionBehaviourFormProps> = ({ nodeId, rea
             Show solutions
           </label>
           <label className={styles.checkRow}>
-            <input type="checkbox" className={styles.checkbox} checked={showHint}
-              disabled={readOnly} onChange={e => patch('showHint', e.target.checked)} />
+            <input type="checkbox" className={styles.checkbox} checked={showHints}
+              disabled={readOnly} onChange={e => patch('showHints', e.target.checked)} />
             Show hint
           </label>
         </div>

--- a/projects/questionset-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
+++ b/projects/questionset-editor-react/src/components/SparkMetaForm/SparkMetaForm.tsx
@@ -201,6 +201,22 @@ function makeFieldValidator(field: ICategoryField) {
 }
 
 // ---------------------------------------------------------------------------
+// Required-field check across an arbitrary field set — used to validate all
+// tabs at once (each tab only mounts its own SparkMetaForm, so per-tab
+// onValidityChange only ever reflects the currently visible tab).
+// ---------------------------------------------------------------------------
+
+export function findMissingRequiredFields(
+  fields: ICategoryField[],
+  values: Record<string, unknown>,
+): ICategoryField[] {
+  return fields.filter((f) => {
+    if (!f.visible || !f.required) return false;
+    return makeFieldValidator(f)(values[f.code]) !== true;
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Helpers — build select/multiselect options
 // ---------------------------------------------------------------------------
 

--- a/projects/questionset-editor-react/src/components/SplitEditorShell/SplitEditorShell.tsx
+++ b/projects/questionset-editor-react/src/components/SplitEditorShell/SplitEditorShell.tsx
@@ -13,8 +13,10 @@ import { label } from '../../utils/labels';
 import { telemetryInteract } from '../../utils/telemetry';
 import ContextualEditor from '../ContextualEditor/ContextualEditor';
 import UnsavedChangesModal from '../modals/UnsavedChangesModal';
+import MissingRequiredFieldsModal, { type MissingFieldGroup } from '../modals/MissingRequiredFieldsModal';
 import { QuestionTypeSelectorModal } from '../modals/QuestionTypeSelectorModal';
 import { ConnectedConfirmDialog } from '../modals/ConfirmDialog';
+import { findMissingRequiredFields } from '../SparkMetaForm/SparkMetaForm';
 
 interface SplitEditorShellProps {
   events: IEditorEvents;
@@ -25,6 +27,7 @@ export function SplitEditorShell({ events }: SplitEditorShellProps) {
   const [showUnsavedPrompt, setShowUnsavedPrompt] = useState(false);
   const [isFormValid, setIsFormValid] = useState(true);
   const [pendingBack, setPendingBack] = useState(false);
+  const [missingFieldGroups, setMissingFieldGroups] = useState<MissingFieldGroup[] | null>(null);
 
   const isDirty = useEditorStore((s) => s.isDirty);
   const editorMode = useEditorStore((s) => s.editorMode);
@@ -72,6 +75,29 @@ export function SplitEditorShell({ events }: SplitEditorShellProps) {
           break;
         }
         case 'saveContent': {
+          // Each tab mounts its own SparkMetaForm, so onFormStatusChange only
+          // ever reflects the currently active tab — check every tab's
+          // required fields against the current node's metadata directly.
+          const { isCurrentNodeRoot, rootFormConfig, unitFormConfig } = useEditorStore.getState();
+          const { activeNodeMeta } = useTreeStore.getState();
+          const fields = isCurrentNodeRoot ? rootFormConfig : unitFormConfig;
+          const missing = findMissingRequiredFields(fields ?? [], activeNodeMeta as Record<string, unknown>);
+          if (missing.length > 0) {
+            const TAB_LABELS: Record<string, string> = {
+              'Audience & Curriculum': label('ui.audience', 'Audience & Curriculum'),
+              Behaviour: label('ui.behaviour', 'Behaviour'),
+            };
+            const detailsLabel = label('ui.details', 'Details');
+            const order: string[] = [];
+            const byTab = new Map<string, string[]>();
+            for (const f of missing) {
+              const tab = (f.section && TAB_LABELS[f.section]) || detailsLabel;
+              if (!byTab.has(tab)) { byTab.set(tab, []); order.push(tab); }
+              byTab.get(tab)!.push(f.label);
+            }
+            setMissingFieldGroups(order.map((tab) => ({ tab, fields: byTab.get(tab)! })));
+            break;
+          }
           if (await save()) notifySuccess(label('messages.success.001', 'Question set saved as draft'));
           break;
         }
@@ -170,6 +196,12 @@ export function SplitEditorShell({ events }: SplitEditorShellProps) {
           onSave={handleSaveAndProceed}
           onCancel={handleCancelUnsaved}
           isSaving={isSaving}
+        />
+      )}
+      {missingFieldGroups && (
+        <MissingRequiredFieldsModal
+          groups={missingFieldGroups}
+          onClose={() => setMissingFieldGroups(null)}
         />
       )}
       <QuestionTypeSelectorModal />

--- a/projects/questionset-editor-react/src/components/Topbar/Topbar.tsx
+++ b/projects/questionset-editor-react/src/components/Topbar/Topbar.tsx
@@ -376,14 +376,14 @@ export const Topbar: React.FC<TopbarProps> = ({
             {L('button_labels.preview_collection_btn_label', 'Preview')}
           </button>
 
-          {/* Save as Draft */}
+          {/* Save as Draft — old editor never gates this on form validity
+              (only visibility/mode); required-field checks belong to
+              Send for Review/Publish, not an in-progress draft save. */}
           {((isEditMode && statusLabel !== 'Review') || reviewerEditAllowed) && (
             <button
               className="ce-btn ghost"
               type="button"
               onClick={() => emit('saveContent')}
-              disabled={!isFormValid}
-              title={!isFormValid ? 'Fill all required fields before saving' : undefined}
             >
               {L('button_labels.save_collection_btn_label', 'Save as Draft')}
             </button>

--- a/projects/questionset-editor-react/src/components/modals/MissingRequiredFieldsModal.tsx
+++ b/projects/questionset-editor-react/src/components/modals/MissingRequiredFieldsModal.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Icon } from '../shared/Icon';
+import { useLabels } from '../../hooks/useLabels';
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+export interface MissingFieldGroup {
+  tab: string;
+  fields: string[];
+}
+
+export interface MissingRequiredFieldsModalProps {
+  groups: MissingFieldGroup[];
+  onClose: () => void;
+}
+
+// -----------------------------------------------------------------------------
+// Component — themed like ConfirmDialog/UnsavedChangesModal (sb-card, ce-btn)
+// -----------------------------------------------------------------------------
+
+const MissingRequiredFieldsModal: React.FC<MissingRequiredFieldsModalProps> = ({ groups, onClose }) => {
+  const L = useLabels();
+
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', h);
+    return () => document.removeEventListener('keydown', h);
+  }, [onClose]);
+
+  const portalTarget = document.querySelector('.ce') ?? document.body;
+
+  return createPortal(
+    <div
+      style={{
+        position: 'fixed', inset: 0, zIndex: 9999,
+        background: 'rgba(0,0,0,0.45)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: 16, fontFamily: 'var(--sb-font)',
+      }}
+      onMouseDown={e => { if (e.target === e.currentTarget) onClose(); }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="missing-fields-title"
+    >
+      <div
+        style={{
+          background: 'var(--sb-card)', borderRadius: 18,
+          width: 480, maxWidth: '100%',
+          display: 'flex', flexDirection: 'column',
+          boxShadow: 'var(--sb-shadow-deep)',
+          overflow: 'hidden',
+        }}
+        onMouseDown={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', padding: '20px 24px 16px' }}>
+          <span id="missing-fields-title" style={{ fontWeight: 800, fontSize: 18, flex: 1, color: 'var(--sb-text)' }}>
+            {L('ui.missingRequiredFieldsTitle', 'Required fields missing')}
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              border: 'none', background: 'transparent', cursor: 'pointer',
+              padding: 4, borderRadius: 6, color: 'var(--sb-text-muted)',
+              display: 'grid', placeItems: 'center',
+            }}
+          >
+            <Icon name="x" size={20} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: '0 24px 24px' }}>
+          <p style={{ fontSize: 15, color: 'var(--sb-text-2)', lineHeight: 1.6, margin: '0 0 10px' }}>
+            {L('ui.missingRequiredFieldsMsg', 'Please fill the following required fields before saving:')}
+          </p>
+          {groups.map((g) => (
+            <div key={g.tab} style={{ marginBottom: 10 }}>
+              <p style={{ fontSize: 13, fontWeight: 700, color: 'var(--sb-text)', margin: '0 0 4px' }}>
+                {g.tab}
+              </p>
+              <ul style={{ margin: 0, paddingLeft: 20, color: 'var(--sb-text-2)', fontSize: 14, lineHeight: 1.8 }}>
+                {g.fields.map((f) => <li key={f}>{f}</li>)}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          display: 'flex', justifyContent: 'flex-end', gap: 10,
+          padding: '16px 24px', borderTop: '1px solid var(--sb-border)',
+        }}>
+          <button type="button" className="ce-btn primary" onClick={onClose}>
+            {L('button_labels.close_btn_label', 'Close')}
+          </button>
+        </div>
+      </div>
+    </div>,
+    portalTarget,
+  );
+};
+
+export default MissingRequiredFieldsModal;

--- a/projects/questionset-editor-react/src/locales/label.config.ar.json
+++ b/projects/questionset-editor-react/src/locales/label.config.ar.json
@@ -368,6 +368,8 @@
     "markMany": "علامات",
     "unsavedChanges": "تغييرات غير محفوظة",
     "unsavedChangesMsg": "لديك تغييرات غير محفوظة. ماذا تريد أن تفعل؟",
+    "missingRequiredFieldsTitle": "حقول مطلوبة مفقودة",
+    "missingRequiredFieldsMsg": "يرجى تعبئة الحقول المطلوبة التالية قبل الحفظ:",
     "stay": "البقاء",
     "discardChanges": "تجاهل التغييرات",
     "saveLeave": "حفظ ومغادرة",

--- a/projects/questionset-editor-react/src/locales/label.config.fr.json
+++ b/projects/questionset-editor-react/src/locales/label.config.fr.json
@@ -359,6 +359,8 @@
     "markMany": "points",
     "unsavedChanges": "Modifications non enregistrées",
     "unsavedChangesMsg": "Vous avez des modifications non enregistrées. Que souhaitez-vous faire ?",
+    "missingRequiredFieldsTitle": "Champs obligatoires manquants",
+    "missingRequiredFieldsMsg": "Veuillez remplir les champs obligatoires suivants avant d'enregistrer :",
     "stay": "Rester",
     "discardChanges": "Annuler les modifications",
     "saveLeave": "Enregistrer et quitter",

--- a/projects/questionset-editor-react/src/locales/label.config.json
+++ b/projects/questionset-editor-react/src/locales/label.config.json
@@ -377,6 +377,8 @@
     "markMany": "marks",
     "unsavedChanges": "Unsaved Changes",
     "unsavedChangesMsg": "You have unsaved changes. What would you like to do?",
+    "missingRequiredFieldsTitle": "Required fields missing",
+    "missingRequiredFieldsMsg": "Please fill the following required fields before saving:",
     "stay": "Stay",
     "discardChanges": "Discard Changes",
     "saveLeave": "Save & Leave",

--- a/projects/questionset-editor-react/src/locales/label.config.pt.json
+++ b/projects/questionset-editor-react/src/locales/label.config.pt.json
@@ -359,6 +359,8 @@
     "markMany": "pontos",
     "unsavedChanges": "Alterações não salvas",
     "unsavedChangesMsg": "Você tem alterações não salvas. O que gostaria de fazer?",
+    "missingRequiredFieldsTitle": "Campos obrigatórios pendentes",
+    "missingRequiredFieldsMsg": "Preencha os seguintes campos obrigatórios antes de salvar:",
     "stay": "Permanecer",
     "discardChanges": "Descartar alterações",
     "saveLeave": "Salvar e sair",


### PR DESCRIPTION
## Summary
- Fix: preview loading/error text rendered as a flex sibling next to the (already-styled) player host box instead of centered over it — now an absolutely-positioned overlay
- Fix: bumped a couple of package versions
- Feat: Save as Draft now validates required fields across **all** metadata tabs (Details/Audience & Curriculum/Behaviour), not just the currently active one, and blocks the save with a popup listing missing fields grouped by tab
- Fix: section \"Show hint\" checkbox wrote `showHint` (singular); player only reads `showHints` (plural), so hints never rendered
- Fix: removed the old `isFormValid`-based disable on Save as Draft (same active-tab-only bug), superseded by the popup validation above