### PR TITLE
Questionset react editor wc

### DIFF
--- a/projects/questionset-editor-react/src/components/SplitEditorShell/SplitEditorShell.tsx
+++ b/projects/questionset-editor-react/src/components/SplitEditorShell/SplitEditorShell.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { EditorRootContext } from '../shared/EditorRootContext';
-import type { IEditorEvents, ToolbarAction } from '../../types/editor';
+import type { IEditorEvents, ToolbarAction, INode } from '../../types/editor';
 import { useTreeStore } from '../../store/tree.store';
 import { useEditorStore } from '../../store/editor.store';
 import { useSaveHierarchy } from '../../hooks/useSaveHierarchy';
@@ -17,6 +17,7 @@ import MissingRequiredFieldsModal, { type MissingFieldGroup } from '../modals/Mi
 import { QuestionTypeSelectorModal } from '../modals/QuestionTypeSelectorModal';
 import { ConnectedConfirmDialog } from '../modals/ConfirmDialog';
 import { findMissingRequiredFields } from '../SparkMetaForm/SparkMetaForm';
+import { detectNodeKind } from '../../utils/nodeKind';
 
 interface SplitEditorShellProps {
   events: IEditorEvents;
@@ -76,26 +77,57 @@ export function SplitEditorShell({ events }: SplitEditorShellProps) {
         }
         case 'saveContent': {
           // Each tab mounts its own SparkMetaForm, so onFormStatusChange only
-          // ever reflects the currently active tab — check every tab's
-          // required fields against the current node's metadata directly.
-          const { isCurrentNodeRoot, rootFormConfig, unitFormConfig } = useEditorStore.getState();
-          const { activeNodeMeta } = useTreeStore.getState();
-          const fields = isCurrentNodeRoot ? rootFormConfig : unitFormConfig;
-          const missing = findMissingRequiredFields(fields ?? [], activeNodeMeta as Record<string, unknown>);
-          if (missing.length > 0) {
-            const TAB_LABELS: Record<string, string> = {
-              'Audience & Curriculum': label('ui.audience', 'Audience & Curriculum'),
-              Behaviour: label('ui.behaviour', 'Behaviour'),
-            };
-            const detailsLabel = label('ui.details', 'Details');
-            const order: string[] = [];
-            const byTab = new Map<string, string[]>();
-            for (const f of missing) {
+          // ever reflects the currently active tab. Save as Draft saves the
+          // whole hierarchy, not just whatever's currently selected, so check
+          // the root AND every section's required fields regardless of
+          // selection — not just the active node. Questions have their own
+          // required-field checks (QuestionEditor's invalidReason) and are
+          // never included here.
+          const { rootFormConfig, unitFormConfig } = useEditorStore.getState();
+          const { treeData, treeCache } = useTreeStore.getState();
+
+          // updateNode() patches land in treeCache (and the node's top-level
+          // props via deepMergeNode), NOT inside node.metadata — activeNodeMeta
+          // overlays treeCache on top of node.metadata for exactly this reason.
+          // Reading node.metadata alone here saw stale, never-updated values.
+          const liveMeta = (node: INode) =>
+            ({ ...(node.metadata ?? {}), ...(treeCache[node.id] ?? {}) }) as Record<string, unknown>;
+
+          const TAB_LABELS: Record<string, string> = {
+            'Audience & Curriculum': label('ui.audience', 'Audience & Curriculum'),
+            Behaviour: label('ui.behaviour', 'Behaviour'),
+          };
+          const detailsLabel = label('ui.details', 'Details');
+          const order: string[] = [];
+          const byGroup = new Map<string, string[]>();
+          const addMissing = (fields: typeof rootFormConfig, meta: Record<string, unknown>, sectionName?: string) => {
+            for (const f of findMissingRequiredFields(fields ?? [], meta)) {
               const tab = (f.section && TAB_LABELS[f.section]) || detailsLabel;
-              if (!byTab.has(tab)) { byTab.set(tab, []); order.push(tab); }
-              byTab.get(tab)!.push(f.label);
+              const group = sectionName ? `${sectionName} — ${tab}` : tab;
+              if (!byGroup.has(group)) { byGroup.set(group, []); order.push(group); }
+              byGroup.get(group)!.push(f.label);
             }
-            setMissingFieldGroups(order.map((tab) => ({ tab, fields: byTab.get(tab)! })));
+          };
+
+          const rootNode = treeData[0];
+          if (rootNode) addMissing(rootFormConfig, liveMeta(rootNode));
+
+          // isFolder from the API is unreliable for questions (they often
+          // come back with isFolder:true) — detectNodeKind checks
+          // mimeType/objectType/isQuestion/questionType first instead.
+          const sections: typeof treeData = [];
+          const queue = [...(rootNode?.children ?? [])];
+          while (queue.length) {
+            const n = queue.shift()!;
+            if (detectNodeKind(n) === 'section') sections.push(n);
+            if (n.children) queue.push(...n.children);
+          }
+          for (const section of sections) {
+            addMissing(unitFormConfig, liveMeta(section), section.name);
+          }
+
+          if (order.length > 0) {
+            setMissingFieldGroups(order.map((tab) => ({ tab, fields: byGroup.get(tab)! })));
             break;
           }
           if (await save()) notifySuccess(label('messages.success.001', 'Question set saved as draft'));

--- a/projects/questionset-editor-react/src/components/shared/MathModal.tsx
+++ b/projects/questionset-editor-react/src/components/shared/MathModal.tsx
@@ -51,6 +51,13 @@ function insertAtRange(html: string, range: Range) {
   }
 }
 
+// Resolved against this bundle's own URL (not the host page's domain root) —
+// this package is published to npm and its dist/ assets get consumed from
+// node_modules by the portal, so a root-relative '/assets/...' path resolves
+// against the portal's own origin instead of wherever this package's dist/
+// actually lives, and 404s through to the portal's own SPA fallback page.
+const MATH_MODAL_URL = new URL('./assets/libs/mathEquation/plugin/mathModal/index.html', import.meta.url).href;
+
 export default function MathModal({ anchor, onClose, savedRange }: MathModalProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
@@ -137,7 +144,7 @@ export default function MathModal({ anchor, onClose, savedRange }: MathModalProp
       >
         <iframe
           ref={iframeRef}
-          src="/assets/libs/mathEquation/plugin/mathModal/index.html"
+          src={MATH_MODAL_URL}
           onLoad={handleLoad}
           style={{ width: '100%', height: '100%', border: 'none', display: 'block' }}
           title="Equation Editor"

--- a/projects/questionset-editor-react/src/hooks/useSaveQuestion.ts
+++ b/projects/questionset-editor-react/src/hooks/useSaveQuestion.ts
@@ -28,6 +28,13 @@ import { v4 as genUuid } from 'uuid';
 // ---------------------------------------------------------------------------
 // body HTML — old editor wraps question in specific template divs
 // ---------------------------------------------------------------------------
+// Old editor's "Grid" MCQ layout button (options.component.html) sets
+// templateId to 'mcq-vertical-split', not 'mcq-grid' — the UI label says
+// "Grid" but the persisted template string doesn't follow the layout name.
+function mcqTemplateId(layout: 'vertical' | 'grid' | 'horizontal'): string {
+  return layout === 'grid' ? 'mcq-vertical-split' : `mcq-${layout}`;
+}
+
 function parseBlanks(questionHtml: string): string[] {
   // Extract from entity-decoded plain text — inline markup (<strong>) or
   // &nbsp; inside [[ ]] would otherwise become part of the correct answer.
@@ -183,6 +190,7 @@ function buildInteractions(type: QuestionType, options: IOption[], questionBody 
 function buildResponseDeclaration(
   type: QuestionType, options: IOption[], questionBody = '',
   matchPairs: IMatchPair[] = [], isPartialScore = true, sequence: string[] = [], sentence = '',
+  evalUnordered = false,
 ): Record<string, unknown> {
   if (type === 'reo') {
     const value = reoOptions(sentence).map((o) => o.value);
@@ -220,17 +228,19 @@ function buildResponseDeclaration(
     return { response1: rd };
   }
   if (type === 'ftb') {
-    // Old editor: one responseN per blank; every response carries the full
-    // mapping of all blank values (score 1 each, caseSensitive false).
+    // Old editor: one responseN per blank. By default each blank's mapping
+    // holds only its own answer; evalUnordered replaces every blank's
+    // mapping with the union of all answers so any blank accepts any
+    // answer, in any order.
     const blanks = parseBlanks(questionBody);
-    const mapping = blanks.map((b) => ({ value: b, score: 1, caseSensitive: false }));
+    const unionMapping = blanks.map((b) => ({ value: b, score: 1, caseSensitive: false }));
     const rd: Record<string, unknown> = {};
     blanks.forEach((b, i) => {
       rd[`response${i + 1}`] = {
         cardinality: 'single',
         type: 'string',
         correctResponse: { value: b },
-        mapping,
+        mapping: evalUnordered ? unionMapping : [{ value: b, score: 1, caseSensitive: false }],
       };
     });
     if (blanks.length) return rd;
@@ -347,17 +357,15 @@ export function useSaveQuestion() {
       ?? (isExisting ? activeQuestion?.name : undefined)
       ?? autoName;
 
-    // FTB scores 1 per blank, MTF 1 per pair (when partial); otherwise Marks
-    // from the details form.
+    // Old editor's real save path (question.component.ts getOutcomeDeclaration)
+    // always uses the Marks form field as outcomeDeclaration.maxScore.defaultValue,
+    // for every question type, regardless of partial scoring — partial scoring
+    // only changes cardinality/mapping, never the marks total itself.
     const blankCount =
       questionType === 'ftb' ? parseBlanks(questionBody).length :
         questionType === 'mtf' ? matchPairs.length : 0;
     const effectiveMaxScore =
-      questionType === 'ftb' && blankCount > 0 ? blankCount :
-        questionType === 'mtf' ? (isPartialScore && blankCount > 0 ? blankCount : 1) :
-          questionType === 'seq' ? (isPartialScore && sequence.length > 0 ? sequence.length : 1) :
-            questionType === 'reo' ? 1 :
-              (Number.isFinite(formMarks) && formMarks > 0 ? formMarks : (maxScore ?? 1));
+      Number.isFinite(formMarks) && formMarks > 0 ? formMarks : (maxScore ?? 1);
 
     // 'multiple' only when the score is actually per-blank — FTB always, MTF
     // only with partial scoring (a scalar defaultValue must stay 'single',
@@ -458,13 +466,13 @@ export function useSaveQuestion() {
           },
           body:        buildBodyHtml(questionType, questionBody),
           answer:      buildAnswerHtml(questionType, options, answerText),
-          ...(questionType === 'mcq' ? { templateId: `mcq-${layout}` } : {}),
+          ...(questionType === 'mcq' ? { templateId: mcqTemplateId(layout) } : {}),
           ...(questionType === 'boolean' ? { templateId: 'boolean' } : {}),
           ...(questionType === 'ftb' ? {
             isPartialScore,
             evalUnordered,
             scoringMode: 'responseProcessing',
-            responseProcessing: { template: 'MAP_RESPONSE' },
+            responseProcessing: { template: isPartialScore ? 'MAP_RESPONSE' : 'MATCH_CORRECT' },
           } : {}),
           ...(questionType === 'mtf' ? {
             pairs: wrapPairs(matchPairs),
@@ -493,7 +501,7 @@ export function useSaveQuestion() {
           // responseDeclaration/hints keys).
           ...(hasInteractions ? {
             interactionTypes: [typeDef?.interactionType ?? 'text'],
-            responseDeclaration: buildResponseDeclaration(questionType, options, questionBody, matchPairs, isPartialScore, sequence, sentence),
+            responseDeclaration: buildResponseDeclaration(questionType, options, questionBody, matchPairs, isPartialScore, sequence, sentence, evalUnordered),
           } : {}),
           // Old MTF/SEQ payloads carry no hints key unless a hint is set.
           // hints key only when a hint actually exists — no empty {} with a
@@ -556,13 +564,13 @@ export function useSaveQuestion() {
           },
           body:        buildBodyHtml(questionType, questionBody),
           answer:      buildAnswerHtml(questionType, options, answerText),
-          ...(questionType === 'mcq' ? { templateId: `mcq-${layout}` } : {}),
+          ...(questionType === 'mcq' ? { templateId: mcqTemplateId(layout) } : {}),
           ...(questionType === 'boolean' ? { templateId: 'boolean' } : {}),
           ...(questionType === 'ftb' ? {
             isPartialScore,
             evalUnordered,
             scoringMode: 'responseProcessing',
-            responseProcessing: { template: 'MAP_RESPONSE' },
+            responseProcessing: { template: isPartialScore ? 'MAP_RESPONSE' : 'MATCH_CORRECT' },
           } : {}),
           ...(questionType === 'mtf' ? {
             pairs: wrapPairs(matchPairs),
@@ -591,7 +599,7 @@ export function useSaveQuestion() {
           // responseDeclaration/hints keys).
           ...(hasInteractions ? {
             interactionTypes: [typeDef?.interactionType ?? 'text'],
-            responseDeclaration: buildResponseDeclaration(questionType, options, questionBody, matchPairs, isPartialScore, sequence, sentence),
+            responseDeclaration: buildResponseDeclaration(questionType, options, questionBody, matchPairs, isPartialScore, sequence, sentence, evalUnordered),
           } : {}),
           // Old MTF/SEQ payloads carry no hints key unless a hint is set.
           // hints key only when a hint actually exists — no empty {} with a

--- a/projects/questionset-editor-react/src/store/question.store.ts
+++ b/projects/questionset-editor-react/src/store/question.store.ts
@@ -325,8 +325,11 @@ export const useQuestionStore = create<QuestionState>((set, get) => ({
       showSolutions: question.showSolutions ?? DEFAULT_META.showSolutions,
       isPartialScore: question.isPartialScore ?? DEFAULT_META.isPartialScore,
       evalUnordered: question.evalUnordered ?? DEFAULT_META.evalUnordered,
-      // Restore the authored MCQ/SEQ layout from the saved templateId
-      layout: question.templateId?.endsWith('-grid') ? 'grid'
+      // Restore the authored MCQ/SEQ layout from the saved templateId.
+      // Old editor's MCQ "Grid" layout persists as 'mcq-vertical-split' (its
+      // UI label doesn't match the templateId string) — '-grid' is also
+      // checked to tolerate content saved by this editor's earlier bug.
+      layout: question.templateId?.endsWith('-vertical-split') || question.templateId?.endsWith('-grid') ? 'grid'
         : question.templateId?.endsWith('-horizontal') ? 'horizontal'
         : 'vertical',
     });


### PR DESCRIPTION
## Summary
- Fix: MCQ "Grid" layout now serializes/deserializes as `mcq-vertical-split` (old editor's real templateId for that button), not `mcq-grid`
- Fix: FTB scoring parity — `responseProcessing.template` now switches MAP_RESPONSE/MATCH_CORRECT with partial scoring like old editor, and `evalUnordered` is actually wired into blank-mapping construction (previously always behaved as if it were on)
- Fix: `outcomeDeclaration.maxScore.defaultValue` always comes from the Marks form field for every question type, matching old editor's real save path — previously hardcoded to 1/blank-count for MTF/SEQ/REO when partial scoring was off, silently discarding a manually-set Marks value
- Fix: equation-editor iframe now resolves its asset URL against this package's own bundle location (`import.meta.url`) instead of a root-relative path — the root-relative path broke once this package is consumed from `node_modules` by the portal (falls through to the portal's own landing page)
- Feat: Save as Draft now validates required fields across the whole hierarchy (root + every section, using live/treeCache-overlaid metadata), not just whatever node happens to be selected, and groups missing fields in the popup by section + tab